### PR TITLE
test: Python pytest example + CI integration job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,62 @@
+name: integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  python:
+    name: pytest example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Build defrost
+        run: go build -o defrost .
+
+      - name: Run defrost against examples/python
+        id: run
+        run: |
+          set +e
+          ./defrost exec --no-persist pytest examples/python/ > out.txt 2>&1
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Assert exit code is non-zero (intentional failures)
+        run: |
+          code="${{ steps.run.outputs.exit }}"
+          echo "defrost exit code: $code"
+          if [ "$code" -eq 0 ]; then
+            echo "FAIL: expected non-zero exit (test_fail, test_raises, test_with_broken_fixture are intentional)"
+            cat out.txt
+            exit 1
+          fi
+
+      - name: Assert result count matches expected
+        run: |
+          count=$(grep -c '^{Id:' out.txt || true)
+          echo "TestResult lines emitted: $count"
+          if [ "$count" -ne 10 ]; then
+            echo "FAIL: expected 10 TestResult lines, got $count"
+            cat out.txt
+            exit 1
+          fi
+
+      - name: Upload defrost output for debugging
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-out
+          path: out.txt

--- a/examples/python/.gitignore
+++ b/examples/python/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,0 +1,24 @@
+# Python integration example
+
+A pytest project covering the cases the defrost pytest adapter parses out
+of JUnit XML. The CI workflow at `.github/workflows/integration.yml`
+runs `defrost exec pytest examples/python/ --no-persist` against this
+directory and asserts on the exit code and result count.
+
+## Test inventory
+
+| File | Test | Outcome | Notes |
+|---|---|---|---|
+| `test_basics.py` | `test_pass` | pass | also exercises `<system-out>` capture (has a `print`) |
+| `test_basics.py` | `test_fail` | fail | plain `AssertionError` |
+| `test_basics.py` | `test_raises` | fail | non-`AssertionError` exception in call phase |
+| `test_skip.py` | `test_skip_decorator` | skip | `@pytest.mark.skip` |
+| `test_skip.py` | `test_skipif_true` | skip | `@pytest.mark.skipif(True, ...)` |
+| `test_parametrize.py` | `test_squared[1-1]` | pass | parametrize expands to 3 testcases |
+| `test_parametrize.py` | `test_squared[2-4]` | pass | |
+| `test_parametrize.py` | `test_squared[3-9]` | pass | |
+| `test_fixtures.py` | `test_uses_fixture` | pass | consumes `good_fixture` from `conftest.py` |
+| `test_fixtures.py` | `test_with_broken_fixture` | error | `broken_fixture` raises during setup → JUnit `<error>` |
+
+10 testcases total: 5 pass, 2 fail, 1 error, 2 skip. pytest exits 1
+because of the failing/erroring tests, so defrost exits 1 too.

--- a/examples/python/conftest.py
+++ b/examples/python/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def good_fixture():
+    return 42
+
+
+@pytest.fixture
+def broken_fixture():
+    raise ValueError("intentional setup failure")

--- a/examples/python/test_basics.py
+++ b/examples/python/test_basics.py
@@ -1,0 +1,11 @@
+def test_pass():
+    print("captured stdout from test_pass")
+    assert 1 == 1
+
+
+def test_fail():
+    assert 1 == 2
+
+
+def test_raises():
+    raise RuntimeError("intentional non-assertion failure")

--- a/examples/python/test_fixtures.py
+++ b/examples/python/test_fixtures.py
@@ -1,0 +1,6 @@
+def test_uses_fixture(good_fixture):
+    assert good_fixture == 42
+
+
+def test_with_broken_fixture(broken_fixture):
+    pass

--- a/examples/python/test_parametrize.py
+++ b/examples/python/test_parametrize.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.mark.parametrize("n,expected", [(1, 1), (2, 4), (3, 9)])
+def test_squared(n, expected):
+    assert n * n == expected

--- a/examples/python/test_skip.py
+++ b/examples/python/test_skip.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.mark.skip(reason="demo: unconditional skip")
+def test_skip_decorator():
+    pass
+
+
+@pytest.mark.skipif(True, reason="demo: skipif true")
+def test_skipif_true():
+    pass


### PR DESCRIPTION
## Summary

- Adds `examples/python/` — a pytest project that exercises every case the pytest adapter parses out of JUnit XML (pass, assertion fail, non-assertion raise, decorator skip, skipif, parametrize expansion, working fixture, broken-fixture `<error>`).
- Adds `.github/workflows/integration.yml` — builds defrost, runs it against the example, and asserts the contract: non-zero exit (intentional fails) and exactly 10 `TestResult` lines emitted.
- `examples/python/.gitignore` keeps `__pycache__` / `.pytest_cache` out of the repo.

## Why

We wanted a per-language integration harness so CI catches regressions in the adapter end-to-end (not just the parser unit tests). The example also doubles as living documentation for what the adapter handles. Same shape (`examples/<lang>/` + a parallel job) hosts a Go example next.

## Test plan

- [x] `defrost exec --no-persist pytest examples/python/` → exits 1, emits 10 `TestResult` lines (5 pass, 2 fail, 1 error, 2 skip).
- [ ] CI workflow runs green on this PR (build + assertion steps both succeed).
- [ ] On intentional break (e.g. flip a `pass` to `fail`), CI fails on the count assertion and uploads `out.txt` as an artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)