### PR TITLE
feat: pluggable persistence backend with --dev mode flag

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -7,7 +7,7 @@ var CLI struct {
 		DataBranch string   `name:"data-branch" default:"_defrost" help:"Branch name where results are stored."`
 		NoPersist  bool     `name:"no-persist" help:"Run tests without persisting results."`
 		NoRemote   bool     `name:"no-remote" help:"Persist locally only — store the data branch in the local repo and do not push."`
-		NoHistory  bool     `name:"no-history" aliases:"nh" help:"Write results to <repo-dir>/.defrost-dev (gitignored scratch dir) instead of committing/pushing. For developing defrost itself."`
+		Dev        bool     `name:"dev" short:"d" help:"Dev mode: write results to <repo-dir>/.defrost-dev (gitignored scratch dir) instead of committing/pushing. For developing defrost itself."`
 	} `cmd:"" help:"Execute test command and persist results."`
 
 	History struct {

--- a/cli.go
+++ b/cli.go
@@ -7,6 +7,7 @@ var CLI struct {
 		DataBranch string   `name:"data-branch" default:"_defrost" help:"Branch name where results are stored."`
 		NoPersist  bool     `name:"no-persist" help:"Run tests without persisting results."`
 		NoRemote   bool     `name:"no-remote" help:"Persist locally only — store the data branch in the local repo and do not push."`
+		NoHistory  bool     `name:"no-history" aliases:"nh" help:"Write results to <repo-dir>/.defrost-dev (gitignored scratch dir) instead of committing/pushing. For developing defrost itself."`
 	} `cmd:"" help:"Execute test command and persist results."`
 
 	History struct {

--- a/exec.go
+++ b/exec.go
@@ -15,7 +15,7 @@ type ExecOpts struct {
 	DataBranch string
 	Persist    bool
 	NoRemote   bool
-	NoHistory  bool
+	Dev        bool
 }
 
 func HandleExecution(cmd []string, opts ExecOpts) int {
@@ -61,7 +61,7 @@ func persistResults(opts ExecOpts, cmd []string, results []models.TestResult) er
 		DataBranch: opts.DataBranch,
 		AuthToken:  os.Getenv("GITHUB_TOKEN"),
 		NoRemote:   opts.NoRemote,
-		NoHistory:  opts.NoHistory,
+		Dev:        opts.Dev,
 	}
 	run, err := persist.DetectRun(pOpts, cmd)
 	if err != nil {

--- a/exec.go
+++ b/exec.go
@@ -15,6 +15,7 @@ type ExecOpts struct {
 	DataBranch string
 	Persist    bool
 	NoRemote   bool
+	NoHistory  bool
 }
 
 func HandleExecution(cmd []string, opts ExecOpts) int {
@@ -60,12 +61,13 @@ func persistResults(opts ExecOpts, cmd []string, results []models.TestResult) er
 		DataBranch: opts.DataBranch,
 		AuthToken:  os.Getenv("GITHUB_TOKEN"),
 		NoRemote:   opts.NoRemote,
+		NoHistory:  opts.NoHistory,
 	}
 	run, err := persist.DetectRun(pOpts, cmd)
 	if err != nil {
 		return fmt.Errorf("detect run: %w", err)
 	}
-	if err := persist.Persist(pOpts, run, results); err != nil {
+	if err := persist.New(pOpts).InsertNewTestResults(run, results); err != nil {
 		if errors.Is(err, persist.ErrNoOrigin) {
 			return errors.New("no 'origin' remote configured. Either add one (`git remote add origin ...`) or pass --no-remote to persist locally only")
 		}

--- a/history.go
+++ b/history.go
@@ -10,12 +10,12 @@ import (
 )
 
 func HandleHistory(testName, repoDir, dataBranch string, noRemote bool) int {
-	entries, err := persist.History(persist.Options{
+	entries, err := persist.New(persist.Options{
 		RepoDir:    repoDir,
 		DataBranch: dataBranch,
 		AuthToken:  os.Getenv("GITHUB_TOKEN"),
 		NoRemote:   noRemote,
-	}, testName)
+	}).GetTestHistory(testName)
 	if err != nil {
 		if errors.Is(err, persist.ErrNoOrigin) {
 			fmt.Fprintln(os.Stderr, "history: no 'origin' remote configured. Either add one (`git remote add origin ...`) or pass --no-remote to read from the local repo.")

--- a/internal/persist/persist.go
+++ b/internal/persist/persist.go
@@ -102,15 +102,16 @@ type Options struct {
 	// local flaky-test tracking.
 	NoRemote bool
 
-	// NoHistory, when true, writes the run record and entry files to
-	// <RepoDir>/.defrost-dev/ (a scratch directory the user gitignores)
-	// and skips all git operations. Intended for developing defrost
-	// itself without polluting the data branch.
-	NoHistory bool
+	// Dev, when true, selects the dev-mode backend: writes the run
+	// record and entry files to <RepoDir>/.defrost-dev/ (a scratch
+	// directory the user gitignores) and skips all git operations.
+	// Intended for developing defrost itself without polluting the
+	// data branch.
+	Dev bool
 }
 
-// NoHistoryDir is the subdirectory of RepoDir used when NoHistory is set.
-const NoHistoryDir = ".defrost-dev"
+// DevDir is the subdirectory of RepoDir used when Dev is set.
+const DevDir = ".defrost-dev"
 
 // Backend is the swappable persistence layer. Implementations decide
 // where run records and test entries live (git data branch, scratch dir,
@@ -133,11 +134,11 @@ type Backend interface {
 	GetTestHistory(testName string) ([]HistoricalEntry, error)
 }
 
-// New returns the Backend implied by opts. NoHistory selects the local
+// New returns the Backend implied by opts. Dev mode selects the local
 // scratch backend; otherwise the git-data-branch backend is used.
 func New(opts Options) Backend {
-	if opts.NoHistory {
-		return &fileBackend{dir: filepath.Join(opts.RepoDir, NoHistoryDir)}
+	if opts.Dev {
+		return &fileBackend{dir: filepath.Join(opts.RepoDir, DevDir)}
 	}
 	return &gitBackend{opts: opts}
 }

--- a/internal/persist/persist.go
+++ b/internal/persist/persist.go
@@ -101,6 +101,45 @@ type Options struct {
 	// in the user's repo and is never pushed anywhere. Useful for purely
 	// local flaky-test tracking.
 	NoRemote bool
+
+	// NoHistory, when true, writes the run record and entry files to
+	// <RepoDir>/.defrost-dev/ (a scratch directory the user gitignores)
+	// and skips all git operations. Intended for developing defrost
+	// itself without polluting the data branch.
+	NoHistory bool
+}
+
+// NoHistoryDir is the subdirectory of RepoDir used when NoHistory is set.
+const NoHistoryDir = ".defrost-dev"
+
+// Backend is the swappable persistence layer. Implementations decide
+// where run records and test entries live (git data branch, scratch dir,
+// SQL database, etc.). All implementations are responsible for atomicity
+// within a single InsertNewTestResults call: either every result lands
+// or none does.
+type Backend interface {
+	// InitialisePersistence prepares storage for first use. Idempotent.
+	// Implementations may be lazy — InsertNewTestResults and
+	// GetTestHistory must work without an explicit prior call.
+	InitialisePersistence() error
+
+	// InsertNewTestResults atomically writes a RunRecord plus one entry
+	// per result. Empty results are a no-op.
+	InsertNewTestResults(run RunRecord, results []models.TestResult) error
+
+	// GetTestHistory returns every persisted entry for the named test,
+	// joined with its RunRecord, oldest first. Returns an empty slice
+	// when the test has no history yet.
+	GetTestHistory(testName string) ([]HistoricalEntry, error)
+}
+
+// New returns the Backend implied by opts. NoHistory selects the local
+// scratch backend; otherwise the git-data-branch backend is used.
+func New(opts Options) Backend {
+	if opts.NoHistory {
+		return &fileBackend{dir: filepath.Join(opts.RepoDir, NoHistoryDir)}
+	}
+	return &gitBackend{opts: opts}
 }
 
 // ErrNoOrigin is returned when the user's repo has no origin remote
@@ -191,16 +230,25 @@ func DetectRun(opts Options, cmd []string) (RunRecord, error) {
 	return run, nil
 }
 
-// Persist writes one RunRecord to runs/<run_id>.json plus one Entry per
-// result to tests/<id>.ndjson, commits, and pushes to origin (or, with
-// NoRemote, into the user's local .git directory).
+// gitBackend stores runs/entries on a dedicated git data branch. Default
+// remote is the user's `origin`; with NoRemote the branch lives only in
+// the user's local .git directory.
 //
-// Concurrent writers are reconciled by retrying push up to maxPushAttempts
-// times. On a non-fast-forward rejection Persist fetches the current tip
-// and rebases — git's three-way merge runs the `merge=union` driver from
-// .gitattributes. RunRecord files have unique filenames per run_id and
-// never conflict.
-func Persist(opts Options, run RunRecord, results []models.TestResult) error {
+// Concurrent writers are reconciled by retrying push up to
+// maxPushAttempts times. On a non-fast-forward rejection the backend
+// fetches the current tip and rebases — git's three-way merge runs the
+// `merge=union` driver from .gitattributes. RunRecord files have unique
+// filenames per run_id and never conflict.
+type gitBackend struct {
+	opts Options
+}
+
+// InitialisePersistence is a no-op: the git backend's storage is the
+// data branch itself, which is created lazily on first write inside
+// InsertNewTestResults (the workdir is per-call and ephemeral).
+func (b *gitBackend) InitialisePersistence() error { return nil }
+
+func (b *gitBackend) InsertNewTestResults(run RunRecord, results []models.TestResult) error {
 	if len(results) == 0 {
 		return nil
 	}
@@ -208,12 +256,12 @@ func Persist(opts Options, run RunRecord, results []models.TestResult) error {
 		return errors.New("persist: empty RunID")
 	}
 
-	branch := opts.DataBranch
+	branch := b.opts.DataBranch
 	if branch == "" {
 		branch = DefaultDataBranch
 	}
 
-	remoteURL, err := resolveTargetURL(opts)
+	remoteURL, err := resolveTargetURL(b.opts)
 	if err != nil {
 		return err
 	}
@@ -249,16 +297,13 @@ func Persist(opts Options, run RunRecord, results []models.TestResult) error {
 	return pushWithRetry(workDir, branch, branchExisted)
 }
 
-// History returns every persisted entry for the named test, joined with
-// its RunRecord, oldest first by entry timestamp. Returns an empty slice
-// if the test has no recorded history yet.
-func History(opts Options, testName string) ([]HistoricalEntry, error) {
-	branch := opts.DataBranch
+func (b *gitBackend) GetTestHistory(testName string) ([]HistoricalEntry, error) {
+	branch := b.opts.DataBranch
 	if branch == "" {
 		branch = DefaultDataBranch
 	}
 
-	remoteURL, err := resolveTargetURL(opts)
+	remoteURL, err := resolveTargetURL(b.opts)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +328,56 @@ func History(opts Options, testName string) ([]HistoricalEntry, error) {
 		return nil, fmt.Errorf("clone data branch: %w", err)
 	}
 
-	path := filepath.Join(workDir, "tests", EncodeTestID(testName)+".ndjson")
+	return readHistoryFromDir(workDir, testName)
+}
+
+// fileBackend writes runs and entries to a plain directory on disk and
+// performs no git operations. The directory is reused across runs so the
+// developer can inspect accumulated output; it is the user's
+// responsibility to gitignore it.
+type fileBackend struct {
+	dir string
+}
+
+func (b *fileBackend) InitialisePersistence() error {
+	if err := os.MkdirAll(b.dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", b.dir, err)
+	}
+	return nil
+}
+
+func (b *fileBackend) InsertNewTestResults(run RunRecord, results []models.TestResult) error {
+	if len(results) == 0 {
+		return nil
+	}
+	if run.RunID == "" {
+		return errors.New("persist: empty RunID")
+	}
+	if err := b.InitialisePersistence(); err != nil {
+		return err
+	}
+	if err := writeRunRecord(b.dir, run); err != nil {
+		return err
+	}
+	return appendEntries(b.dir, run, results)
+}
+
+func (b *fileBackend) GetTestHistory(testName string) ([]HistoricalEntry, error) {
+	if _, err := os.Stat(b.dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return readHistoryFromDir(b.dir, testName)
+}
+
+// readHistoryFromDir reads tests/<id>.ndjson from a directory laid out
+// like the data branch and joins each entry with its RunRecord from
+// runs/<run_id>.json. Shared by gitBackend (after cloning) and
+// fileBackend.
+func readHistoryFromDir(dir, testName string) ([]HistoricalEntry, error) {
+	path := filepath.Join(dir, "tests", EncodeTestID(testName)+".ndjson")
 	f, err := os.Open(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -304,7 +398,7 @@ func History(opts Options, testName string) ([]HistoricalEntry, error) {
 	for _, e := range entries {
 		rec, ok := runCache[e.RunID]
 		if !ok {
-			rec, _ = readRunRecord(workDir, e.RunID)
+			rec, _ = readRunRecord(dir, e.RunID)
 			runCache[e.RunID] = rec
 		}
 		out = append(out, HistoricalEntry{Test: e, Run: rec})
@@ -396,7 +490,10 @@ func localGitDir(repoDir string) (string, error) {
 	if !filepath.IsAbs(out) {
 		out = filepath.Join(repoDir, out)
 	}
-	return filepath.Clean(out), nil
+	// Must be absolute: this path is used as the origin URL for an
+	// ephemeral workdir elsewhere on disk, so a relative path would
+	// resolve against the wrong cwd and the push would silently no-op.
+	return filepath.Abs(out)
 }
 
 // branchExistsOnRemote returns true iff refs/heads/<branch> is published

--- a/internal/persist/persist_test.go
+++ b/internal/persist/persist_test.go
@@ -69,7 +69,7 @@ func TestPersist_CreatesDataBranchOnFirstWrite(t *testing.T) {
 	}
 	run := newTestRun("run-001", "abc123def4567890", "main")
 
-	if err := Persist(Options{RepoDir: repoDir}, run, results); err != nil {
+	if err := New(Options{RepoDir: repoDir}).InsertNewTestResults(run, results); err != nil {
 		t.Fatalf("Persist: %v", err)
 	}
 
@@ -117,7 +117,7 @@ func TestPersist_AppendsToExistingBranch(t *testing.T) {
 		StartTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 	}}
 	run1 := newTestRun("run-A", "1111111111111111", "main")
-	if err := Persist(Options{RepoDir: repoDir}, run1, first); err != nil {
+	if err := New(Options{RepoDir: repoDir}).InsertNewTestResults(run1, first); err != nil {
 		t.Fatalf("first Persist: %v", err)
 	}
 
@@ -129,7 +129,7 @@ func TestPersist_AppendsToExistingBranch(t *testing.T) {
 		StartTime: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
 	}}
 	run2 := newTestRun("run-B", "2222222222222222", "main")
-	if err := Persist(Options{RepoDir: repoDir}, run2, second); err != nil {
+	if err := New(Options{RepoDir: repoDir}).InsertNewTestResults(run2, second); err != nil {
 		t.Fatalf("second Persist: %v", err)
 	}
 
@@ -177,11 +177,11 @@ func TestHistory_RoundTripJoinsRunRecord(t *testing.T) {
 	run.Dirty = true
 	run.DirtyHash = "abcd1234"
 
-	if err := Persist(Options{RepoDir: repoDir}, run, in); err != nil {
+	if err := New(Options{RepoDir: repoDir}).InsertNewTestResults(run, in); err != nil {
 		t.Fatalf("Persist: %v", err)
 	}
 
-	got, err := History(Options{RepoDir: repoDir}, "github.com/x/p/TestA")
+	got, err := New(Options{RepoDir: repoDir}).GetTestHistory("github.com/x/p/TestA")
 	if err != nil {
 		t.Fatalf("History: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestPushWithRetry_RebasesOnConflict(t *testing.T) {
 		Duration:  1 * time.Millisecond,
 		StartTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 	}}
-	if err := Persist(Options{RepoDir: repoDir}, newTestRun("run-seed", "1111111111111111", "main"), seed); err != nil {
+	if err := New(Options{RepoDir: repoDir}).InsertNewTestResults(newTestRun("run-seed", "1111111111111111", "main"), seed); err != nil {
 		t.Fatalf("seed Persist: %v", err)
 	}
 
@@ -277,7 +277,7 @@ func TestPushWithRetry_RebasesOnConflict(t *testing.T) {
 		Duration:  3 * time.Millisecond,
 		StartTime: time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC),
 	}}
-	if err := Persist(Options{RepoDir: repoDir}, newTestRun("run-racer", "3333333333333333", "main"), racer); err != nil {
+	if err := New(Options{RepoDir: repoDir}).InsertNewTestResults(newTestRun("run-racer", "3333333333333333", "main"), racer); err != nil {
 		t.Fatalf("racer Persist: %v", err)
 	}
 
@@ -306,7 +306,7 @@ func TestPushWithRetry_RebasesOnConflict(t *testing.T) {
 func TestHistory_UnknownTestReturnsEmpty(t *testing.T) {
 	requireGit(t)
 	repoDir, _ := makeFixture(t)
-	got, err := History(Options{RepoDir: repoDir}, "github.com/x/p/NeverWritten")
+	got, err := New(Options{RepoDir: repoDir}).GetTestHistory("github.com/x/p/NeverWritten")
 	if err != nil {
 		t.Fatalf("History on empty origin: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestPersist_LocalOnlyNoRemote(t *testing.T) {
 		StartTime: time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
 	}}
 	run := newTestRun("local-run", "abc123", "main")
-	if err := Persist(Options{RepoDir: dir, NoRemote: true}, run, results); err != nil {
+	if err := New(Options{RepoDir: dir, NoRemote: true}).InsertNewTestResults(run, results); err != nil {
 		t.Fatalf("Persist (no-remote): %v", err)
 	}
 
@@ -377,12 +377,84 @@ func TestPersist_LocalOnlyNoRemote(t *testing.T) {
 		t.Errorf("test ndjson missing run_id %q:\n%s", run.RunID, out)
 	}
 
-	hist, err := History(Options{RepoDir: dir, NoRemote: true}, "p/TestA")
+	hist, err := New(Options{RepoDir: dir, NoRemote: true}).GetTestHistory("p/TestA")
 	if err != nil {
 		t.Fatalf("History (no-remote): %v", err)
 	}
 	if len(hist) != 1 || hist[0].Test.RunID != run.RunID {
 		t.Fatalf("unexpected history: %+v", hist)
+	}
+}
+
+// TestPersist_LocalOnlyNoRemote_RelativeRepoDir guards the localGitDir
+// regression: when RepoDir was passed as a relative path (e.g. "."), the
+// resolved .git path stayed relative and the push from the ephemeral
+// workdir silently no-op'd against the wrong cwd.
+func TestPersist_LocalOnlyNoRemote_RelativeRepoDir(t *testing.T) {
+	requireGit(t)
+	parent := t.TempDir()
+	gitMust(t, "", "init", "-b", "main", filepath.Join(parent, "repo"))
+	gitMust(t, filepath.Join(parent, "repo"), "config", "user.email", "t@example.com")
+	gitMust(t, filepath.Join(parent, "repo"), "config", "user.name", "t")
+	gitMust(t, filepath.Join(parent, "repo"), "commit", "--allow-empty", "-m", "init")
+
+	t.Chdir(parent)
+
+	results := []models.TestResult{{
+		Id:        "p/TestA",
+		Ran:       true,
+		Passed:    true,
+		Duration:  1 * time.Millisecond,
+		StartTime: time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
+	}}
+	run := newTestRun("rel-run", "abc123", "main")
+	if err := New(Options{RepoDir: "repo", NoRemote: true}).InsertNewTestResults(run, results); err != nil {
+		t.Fatalf("Persist (no-remote, relative): %v", err)
+	}
+
+	out, err := exec.Command("git", "-C", "repo", "show", DefaultDataBranch+":tests/"+EncodeTestID("p/TestA")+".ndjson").CombinedOutput()
+	if err != nil {
+		t.Fatalf("read tests file from data branch: %v: %s", err, out)
+	}
+	if !strings.Contains(string(out), run.RunID) {
+		t.Errorf("test ndjson missing run_id %q:\n%s", run.RunID, out)
+	}
+}
+
+func TestPersist_NoHistoryWritesScratchDirAndSkipsGit(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	gitMust(t, "", "init", "-b", "main", dir)
+
+	results := []models.TestResult{{
+		Id:        "p/TestA",
+		Ran:       true,
+		Passed:    true,
+		Duration:  1 * time.Millisecond,
+		StartTime: time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
+	}}
+	run := newTestRun("nohist-run", "abc123", "main")
+	if err := New(Options{RepoDir: dir, NoHistory: true}).InsertNewTestResults(run, results); err != nil {
+		t.Fatalf("Persist (no-history): %v", err)
+	}
+
+	scratch := filepath.Join(dir, NoHistoryDir)
+	runPath := filepath.Join(scratch, "runs", run.RunID+".json")
+	if _, err := os.Stat(runPath); err != nil {
+		t.Errorf("run record not written to scratch dir: %v", err)
+	}
+	entryPath := filepath.Join(scratch, "tests", EncodeTestID("p/TestA")+".ndjson")
+	b, err := os.ReadFile(entryPath)
+	if err != nil {
+		t.Fatalf("entry file not written: %v", err)
+	}
+	if !strings.Contains(string(b), run.RunID) {
+		t.Errorf("entry file missing run_id %q:\n%s", run.RunID, b)
+	}
+
+	// No data branch ref should exist — git path was skipped.
+	if out, err := exec.Command("git", "-C", dir, "rev-parse", "--verify", DefaultDataBranch).CombinedOutput(); err == nil {
+		t.Errorf("expected no %s branch, but rev-parse succeeded: %s", DefaultDataBranch, out)
 	}
 }
 
@@ -392,7 +464,7 @@ func TestPersist_RequiresOriginByDefault(t *testing.T) {
 	gitMust(t, "", "init", dir)
 	results := []models.TestResult{{Id: "p/TestA", Ran: true, Passed: true}}
 	run := newTestRun("orphan-run", "abc", "main")
-	err := Persist(Options{RepoDir: dir}, run, results)
+	err := New(Options{RepoDir: dir}).InsertNewTestResults(run, results)
 	if !errors.Is(err, ErrNoOrigin) {
 		t.Errorf("expected ErrNoOrigin, got %v", err)
 	}

--- a/internal/persist/persist_test.go
+++ b/internal/persist/persist_test.go
@@ -421,7 +421,7 @@ func TestPersist_LocalOnlyNoRemote_RelativeRepoDir(t *testing.T) {
 	}
 }
 
-func TestPersist_NoHistoryWritesScratchDirAndSkipsGit(t *testing.T) {
+func TestPersist_DevModeWritesScratchDirAndSkipsGit(t *testing.T) {
 	requireGit(t)
 	dir := t.TempDir()
 	gitMust(t, "", "init", "-b", "main", dir)
@@ -433,12 +433,12 @@ func TestPersist_NoHistoryWritesScratchDirAndSkipsGit(t *testing.T) {
 		Duration:  1 * time.Millisecond,
 		StartTime: time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
 	}}
-	run := newTestRun("nohist-run", "abc123", "main")
-	if err := New(Options{RepoDir: dir, NoHistory: true}).InsertNewTestResults(run, results); err != nil {
-		t.Fatalf("Persist (no-history): %v", err)
+	run := newTestRun("dev-run", "abc123", "main")
+	if err := New(Options{RepoDir: dir, Dev: true}).InsertNewTestResults(run, results); err != nil {
+		t.Fatalf("Persist (dev): %v", err)
 	}
 
-	scratch := filepath.Join(dir, NoHistoryDir)
+	scratch := filepath.Join(dir, DevDir)
 	runPath := filepath.Join(scratch, "runs", run.RunID+".json")
 	if _, err := os.Stat(runPath); err != nil {
 		t.Errorf("run record not written to scratch dir: %v", err)

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 			DataBranch: CLI.Exec.DataBranch,
 			Persist:    !CLI.Exec.NoPersist,
 			NoRemote:   CLI.Exec.NoRemote,
-			NoHistory:  CLI.Exec.NoHistory,
+			Dev:        CLI.Exec.Dev,
 		}))
 	case strings.HasPrefix(cmd, "history"):
 		os.Exit(HandleHistory(CLI.History.Test, CLI.History.RepoDir, CLI.History.DataBranch, CLI.History.NoRemote))

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 			DataBranch: CLI.Exec.DataBranch,
 			Persist:    !CLI.Exec.NoPersist,
 			NoRemote:   CLI.Exec.NoRemote,
+			NoHistory:  CLI.Exec.NoHistory,
 		}))
 	case strings.HasPrefix(cmd, "history"):
 		os.Exit(HandleHistory(CLI.History.Test, CLI.History.RepoDir, CLI.History.DataBranch, CLI.History.NoRemote))


### PR DESCRIPTION
## Summary

Three related changes:

1. **`--dev` / `-d` flag on `exec`** — selects dev mode, which writes results to `<repo-dir>/.defrost-dev/` (a gitignored scratch dir) instead of committing/pushing. For developing defrost itself without polluting the data branch. The flag is intentionally broad so future dev-only behaviours can be gated by the same switch without growing the flag surface.

2. **Pluggable `Backend` interface** in `internal/persist`, so a SQL-style store can be swapped in later:

   ```go
   type Backend interface {
       InitialisePersistence() error
       InsertNewTestResults(run RunRecord, results []TestResult) error
       GetTestHistory(testName string) ([]HistoricalEntry, error)
   }
   ```

   Two implementations ship now:
   - `gitBackend` — existing data-branch behaviour (remote or `--no-remote`).
   - `fileBackend` — wraps the `.defrost-dev/` flow and is now a complete read+write backend (no longer write-only).

   Selection: `persist.New(opts)` routes by `opts.Dev`. `exec.go` and `history.go` go through the interface. No new flags or config — selection is implied by the existing `--no-remote` / `--dev` flags.

3. **Bug fix in `localGitDir`** — discovered while smoke-testing. When `--repo-dir` was relative (e.g. `.`), the resolved `.git` path stayed relative, and the push from the ephemeral workdir failed because the origin URL didn't resolve from the workdir's cwd. Now resolved via `filepath.Abs`, with a regression test (`TestPersist_LocalOnlyNoRemote_RelativeRepoDir`) that uses `t.Chdir` + a relative `RepoDir`.

## Notes for reviewers

- Free functions `Persist`, `History`, and `persistNoHistory` are removed — call sites and tests use `New(opts).<method>` instead.
- `gitBackend.InitialisePersistence` is a no-op (storage is created lazily inside `InsertNewTestResults` via the per-call temp workdir). `fileBackend.InitialisePersistence` is `MkdirAll` and idempotent.
- Read path is shared via a private `readHistoryFromDir` helper — gitBackend reads after cloning, fileBackend reads the scratch dir directly.
- The flag started life as `--no-history` / `--nh`; renamed to `--dev` / `-d` in a follow-up commit so it can host future dev-mode behaviours. No backward-compat alias kept (it never shipped to users).

## Test plan

- [x] `go test ./...` — all green, including the new `TestPersist_DevModeWritesScratchDirAndSkipsGit` and `TestPersist_LocalOnlyNoRemote_RelativeRepoDir`
- [x] `go vet ./...` — clean
- [x] Smoke test: `defrost exec --dev go test -json ./...` writes to `.defrost-dev/runs/` and `.defrost-dev/tests/`, no git refs created
- [x] Smoke test: `defrost exec --no-remote --repo-dir=.` (relative) now lands the `_defrost` branch (was previously erroring)
- [x] Confirmed regression test fails with the bug present, passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)