### PR TITLE
feat(adapters): graceful degradation + universal passthrough

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bjk95/defrost/internal/persist"
 	"github.com/bjk95/defrost/internal/python/pytest"
 	"github.com/bjk95/defrost/internal/runner"
+	"github.com/bjk95/defrost/internal/runner/passthrough"
 )
 
 // defrostVersion is stamped into the Resource attribute service.version.
@@ -46,9 +47,15 @@ func HandleExecution(cmd []string, opts ExecOpts) int {
 	reg.Register(golang.Adapter{})
 	reg.Register(pytest.Adapter{})
 	reg.Register(&jest.Adapter{})
+	// Passthrough must be registered last: it matches everything, so
+	// anything ahead of it gets first crack at recognising the cmd.
+	reg.Register(passthrough.Adapter{})
 
 	a := reg.Find(cmd)
 	if a == nil {
+		// Unreachable while the passthrough adapter is registered, but kept
+		// as a safety net so a future registry change can't silently turn
+		// "no adapter" into a panic.
 		fmt.Fprintf(os.Stderr, "exec: unsupported test command: %q\n", cmd[0])
 		return 2
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -217,6 +217,23 @@ func TestExec_FileErrorAlongsideSuppressedTest_NotRewritten(t *testing.T) {
 	}
 }
 
+// TestHandleExecution_UnknownCommand_FallsThroughToPassthrough confirms that
+// `defrost exec <anything>` runs the user's command via the passthrough
+// adapter rather than refusing with exit 2 when no framework adapter
+// matches. Regression-protects the "wrap any run command" guarantee.
+func TestHandleExecution_UnknownCommand_FallsThroughToPassthrough(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	// Persist off so we don't need a git repo. The command exits 9 — the
+	// passthrough adapter must propagate that, not synthesise its own
+	// "unknown command" exit 2.
+	got := HandleExecution([]string{"sh", "-c", "exit 9"}, ExecOpts{Persist: false})
+	if got != 9 {
+		t.Errorf("want exit 9 from passthrough, got %d", got)
+	}
+}
+
 func TestExec_BuildOnlyFailure_NotSuppressed(t *testing.T) {
 	repoDir := makeRepo(t)
 	// "buildErr" is the only ID present; suppress it. We must NOT rewrite

--- a/internal/golang/executor.go
+++ b/internal/golang/executor.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/bjk95/defrost/internal/models"
+	"github.com/bjk95/defrost/internal/runner"
 )
 
 // ExecuteGoTest runs cmd, parses test events from its stdout, and returns
@@ -25,18 +26,21 @@ func ExecuteGoTest(cmd []string) ([]models.TestResult, int) {
 		fmt.Fprintln(os.Stderr, err)
 		return nil, 1
 	}
+	c.Stdin = os.Stdin
 	c.Stderr = os.Stderr
 
 	if err := c.Start(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return nil, 1
 	}
+	stop := runner.ForwardSignals(c)
+	defer stop()
 
 	results, parseErr := Parse(stdout)
 	waitErr := c.Wait()
 
 	if parseErr != nil {
-		fmt.Fprintln(os.Stderr, parseErr)
+		fmt.Fprintln(os.Stderr, "defrost: parse go test output:", parseErr)
 	}
 
 	if e, ok := waitErr.(*exec.ExitError); ok {

--- a/internal/javascript/jest/adapter.go
+++ b/internal/javascript/jest/adapter.go
@@ -184,19 +184,25 @@ func looksLikeJestScript(value string) bool {
 }
 
 func (a *Adapter) Run(cmd []string) ([]models.TestResult, int) {
+	// Conditions where we can't safely inject --json/--outputFile or
+	// can't capture results at all (watch mode). Surface a warning and
+	// fall through to passthrough rather than refusing to run — defrost
+	// is a wrapper, the user's command should still execute.
 	if hasUserJSONFlag(cmd) {
-		fmt.Fprintln(os.Stderr, "defrost: jest adapter requires control of --json and --outputFile; remove those flags")
-		return nil, 2
+		fmt.Fprintln(os.Stderr,
+			"defrost: jest --json/--outputFile present in argv; running passthrough (no per-test results will be recorded)")
+		return passthroughRun(cmd)
 	}
 	if hasUserWatchFlag(cmd) {
-		fmt.Fprintln(os.Stderr, "defrost: jest adapter is not compatible with --watch / --watchAll")
-		return nil, 2
+		fmt.Fprintln(os.Stderr,
+			"defrost: jest --watch/--watchAll present; running passthrough (no per-test results will be recorded)")
+		return passthroughRun(cmd)
 	}
 	if a.formD && !a.scriptOK {
 		fmt.Fprintf(os.Stderr,
-			"defrost: scripts.%s in package.json doesn't look like a direct jest invocation; run jest via 'npx jest …' or rewrite the script\n",
+			"defrost: scripts.%s in package.json isn't a direct jest invocation; running passthrough (no per-test results will be recorded). For per-test results, run jest via 'npx jest …' or simplify the script.\n",
 			a.scriptName)
-		return nil, 2
+		return passthroughRun(cmd)
 	}
 
 	f, err := os.CreateTemp("", "defrost-jest-*.json")
@@ -211,35 +217,64 @@ func (a *Adapter) Run(cmd []string) ([]models.TestResult, int) {
 	args := buildArgs(cmd, path)
 
 	child := exec.Command(cmd[0], args...)
-	child.Stdout = os.Stdout
-	child.Stderr = os.Stderr
-
-	runErr := child.Run()
-	exitCode := 0
-	switch e := runErr.(type) {
-	case nil:
-		// success
-	case *exec.ExitError:
-		exitCode = e.ExitCode()
-	default:
-		fmt.Fprintln(os.Stderr, "defrost:", runErr)
+	exitCode, err := runner.RunChild(child)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "defrost:", err)
 		return nil, 1
 	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "defrost:", err)
-		return nil, 1
+		return nil, exitCode
 	}
+	return parseOrPreserve(path, cwd, exitCode)
+}
 
-	results, parseErr := ParseFile(path, cwd)
-	if parseErr != nil {
-		fmt.Fprintln(os.Stderr, "defrost:", parseErr)
-		return nil, 1
+// parseOrPreserve reads jest's JSON output and returns the parsed test
+// results paired with the child's exit code. When the output file is
+// missing/empty (child crashed before writing) or the JSON can't be
+// parsed, the exit code is preserved and a warning is logged — the
+// adapter never overwrites a meaningful child exit with a synthetic
+// parse-error 1, since that would mask the real failure signal.
+func parseOrPreserve(path, cwd string, exitCode int) ([]models.TestResult, int) {
+	if !fileNonEmpty(path) {
+		fmt.Fprintf(os.Stderr,
+			"defrost: jest exited %d without writing JSON output; recording run with no per-test results\n",
+			exitCode)
+		return nil, exitCode
+	}
+	results, err := ParseFile(path, cwd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"defrost: parse jest output: %v; recording run with no per-test results\n",
+			err)
+		return nil, exitCode
 	}
 	runner.ApplyRepoPrefix(results)
-
 	return results, exitCode
+}
+
+func fileNonEmpty(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Size() > 0
+}
+
+// passthroughRun executes cmd verbatim with stdio + signals wired,
+// returning the child exit code and no test results. Used when the jest
+// adapter recognises the invocation form but can't safely capture
+// results (user-supplied --json, --watch, or non-direct script shape).
+func passthroughRun(cmd []string) ([]models.TestResult, int) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	code, err := runner.RunChild(c)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "defrost:", err)
+		return nil, 1
+	}
+	return nil, code
 }
 
 // buildArgs returns the args to pass to cmd[0], with --json and

--- a/internal/javascript/jest/adapter_test.go
+++ b/internal/javascript/jest/adapter_test.go
@@ -357,6 +357,51 @@ func TestBuildArgs(t *testing.T) {
 	}
 }
 
+func TestParseOrPreserve_MissingFile_PreservesExitCode(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope.json")
+
+	results, code := parseOrPreserve(missing, dir, 7)
+	if results != nil {
+		t.Errorf("expected nil results, got %v", results)
+	}
+	if code != 7 {
+		t.Errorf("got code %d, want 7 (child exit must be preserved)", code)
+	}
+}
+
+func TestParseOrPreserve_EmptyFile_PreservesExitCode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, code := parseOrPreserve(path, dir, 2)
+	if results != nil {
+		t.Errorf("expected nil results, got %v", results)
+	}
+	if code != 2 {
+		t.Errorf("got code %d, want 2", code)
+	}
+}
+
+func TestParseOrPreserve_MalformedJSON_PreservesExitCode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.json")
+	if err := os.WriteFile(path, []byte("not jest json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, code := parseOrPreserve(path, dir, 4)
+	if results != nil {
+		t.Errorf("expected nil results, got %v", results)
+	}
+	if code != 4 {
+		t.Errorf("got code %d, want 4", code)
+	}
+}
+
 func TestHasUserJSONFlag(t *testing.T) {
 	cases := []struct {
 		cmd  []string

--- a/internal/python/pytest/adapter.go
+++ b/internal/python/pytest/adapter.go
@@ -42,8 +42,18 @@ func (Adapter) Matches(cmd []string) bool {
 
 func (Adapter) Run(cmd []string) ([]models.TestResult, int) {
 	if hasUserJunitxml(cmd) {
-		fmt.Fprintln(os.Stderr, "defrost: pytest adapter requires control of --junitxml; remove your --junitxml flag")
-		return nil, 2
+		// User-controlled --junitxml means we can't inject our own without
+		// silently overriding their config. Run their command unchanged
+		// and skip per-test parsing rather than refusing to run.
+		fmt.Fprintln(os.Stderr,
+			"defrost: pytest --junitxml present in argv; running passthrough (no per-test results will be recorded)")
+		c := exec.Command(cmd[0], cmd[1:]...)
+		code, err := runner.RunChild(c)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "defrost:", err)
+			return nil, 1
+		}
+		return nil, code
 	}
 
 	f, err := os.CreateTemp("", "defrost-pytest-*.xml")
@@ -63,29 +73,45 @@ func (Adapter) Run(cmd []string) ([]models.TestResult, int) {
 	)
 
 	child := exec.Command(cmd[0], args...)
-	child.Stdout = os.Stdout
-	child.Stderr = os.Stderr
-
-	runErr := child.Run()
-	exitCode := 0
-	switch e := runErr.(type) {
-	case nil:
-		// success
-	case *exec.ExitError:
-		exitCode = e.ExitCode()
-	default:
-		fmt.Fprintln(os.Stderr, "defrost:", runErr)
+	exitCode, err := runner.RunChild(child)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "defrost:", err)
 		return nil, 1
 	}
 
-	results, parseErr := ParseFile(path)
-	if parseErr != nil {
-		fmt.Fprintln(os.Stderr, "defrost:", parseErr)
-		return nil, 1
+	return parseOrPreserve(path, exitCode)
+}
+
+// parseOrPreserve reads pytest's JUnit XML and returns the parsed test
+// results paired with the child's exit code. Pytest exits 5 when no
+// tests were collected and exits non-zero on internal errors (config
+// error, plugin crash); in both cases the XML may be missing or empty.
+// Preserve pytest's exit code rather than overwriting with a synthetic
+// 1 — that's the only signal the user has and we mustn't overwrite it.
+func parseOrPreserve(path string, exitCode int) ([]models.TestResult, int) {
+	if !fileNonEmpty(path) {
+		fmt.Fprintf(os.Stderr,
+			"defrost: pytest exited %d without writing JUnit XML; recording run with no per-test results\n",
+			exitCode)
+		return nil, exitCode
+	}
+	results, err := ParseFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"defrost: parse pytest output: %v; recording run with no per-test results\n",
+			err)
+		return nil, exitCode
 	}
 	runner.ApplyRepoPrefix(results)
-
 	return results, exitCode
+}
+
+func fileNonEmpty(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Size() > 0
 }
 
 func hasUserJunitxml(cmd []string) bool {

--- a/internal/python/pytest/adapter_test.go
+++ b/internal/python/pytest/adapter_test.go
@@ -1,6 +1,10 @@
 package pytest
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestAdapterMatches(t *testing.T) {
 	cases := []struct {
@@ -34,5 +38,47 @@ func TestAdapterMatches(t *testing.T) {
 				t.Fatalf("Matches(%v) = %v, want %v", tc.cmd, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseOrPreserve_MissingFile_PreservesExitCode(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.xml")
+
+	results, code := parseOrPreserve(missing, 5)
+	if results != nil {
+		t.Errorf("expected nil results, got %v", results)
+	}
+	if code != 5 {
+		t.Errorf("got code %d, want 5 (pytest exit must be preserved)", code)
+	}
+}
+
+func TestParseOrPreserve_EmptyFile_PreservesExitCode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.xml")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, code := parseOrPreserve(path, 2)
+	if results != nil {
+		t.Errorf("expected nil results, got %v", results)
+	}
+	if code != 2 {
+		t.Errorf("got code %d, want 2", code)
+	}
+}
+
+func TestParseOrPreserve_MalformedXML_PreservesExitCode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broken.xml")
+	if err := os.WriteFile(path, []byte("<garbage"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, code := parseOrPreserve(path, 3)
+	if results != nil {
+		t.Errorf("expected nil results, got %v", results)
+	}
+	if code != 3 {
+		t.Errorf("got code %d, want 3", code)
 	}
 }

--- a/internal/runner/exec.go
+++ b/internal/runner/exec.go
@@ -1,0 +1,77 @@
+package runner
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+// ForwardSignals installs a forwarder that re-sends SIGINT, SIGTERM, SIGHUP
+// and SIGQUIT received by the parent to c.Process. The returned stop func
+// MUST be called after c.Wait() returns; it tears down the signal handler
+// and the goroutine it owns.
+//
+// Without this, a `kill -TERM` against the defrost process would leave the
+// child orphaned and still running. The default behaviour for terminal
+// SIGINT (Ctrl+C) already reaches the child via the foreground process
+// group, but explicit forwarding makes shutdown deterministic regardless
+// of how the parent is signalled.
+func ForwardSignals(c *exec.Cmd) func() {
+	sigCh := make(chan os.Signal, 4)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case sig := <-sigCh:
+				if c.Process != nil {
+					_ = c.Process.Signal(sig)
+				}
+			case <-stop:
+				return
+			}
+		}
+	}()
+	return func() {
+		signal.Stop(sigCh)
+		close(stop)
+		<-done
+	}
+}
+
+// RunChild starts c with stdio wired to the parent's, forwards relevant
+// termination signals, and waits for it to exit. Returns the child's
+// exit code. On a non-exit error (binary not found, fork failure) returns
+// -1 and the error.
+//
+// Adapters that need to capture the child's stdout for parsing (e.g.
+// `go test -json`) should not use this helper — they construct the pipe
+// themselves and call ForwardSignals directly.
+func RunChild(c *exec.Cmd) (int, error) {
+	if c.Stdin == nil {
+		c.Stdin = os.Stdin
+	}
+	if c.Stdout == nil {
+		c.Stdout = os.Stdout
+	}
+	if c.Stderr == nil {
+		c.Stderr = os.Stderr
+	}
+	if err := c.Start(); err != nil {
+		return -1, err
+	}
+	stop := ForwardSignals(c)
+	defer stop()
+
+	err := c.Wait()
+	if err == nil {
+		return 0, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), nil
+	}
+	return -1, err
+}

--- a/internal/runner/exec.go
+++ b/internal/runner/exec.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -12,11 +13,23 @@ import (
 // MUST be called after c.Wait() returns; it tears down the signal handler
 // and the goroutine it owns.
 //
-// Without this, a `kill -TERM` against the defrost process would leave the
-// child orphaned and still running. The default behaviour for terminal
-// SIGINT (Ctrl+C) already reaches the child via the foreground process
-// group, but explicit forwarding makes shutdown deterministic regardless
-// of how the parent is signalled.
+// SIGINT has two-stage semantics, matching the convention of bash, npm,
+// pytest, and most language runtimes: the first Ctrl+C forwards to the
+// child for graceful shutdown; the second SIGKILLs the child and exits
+// the parent with 130 (128 + SIGINT). Without the second-press escape
+// hatch, a child that ignores or hangs on SIGINT would trap the user —
+// once we call signal.Notify on SIGINT the Go runtime stops killing the
+// parent on it, so we have to provide the way out ourselves.
+//
+// Other terminating signals are forwarded once and don't trigger the
+// force-quit path; those are typically `kill <pid>` and the operator
+// already chose the signal level.
+//
+// Without this forwarder a `kill -TERM` against the defrost process
+// would leave the child orphaned and still running. The default
+// behaviour for terminal SIGINT also reaches the child via the
+// foreground process group, but explicit forwarding makes shutdown
+// deterministic regardless of how the parent is signalled.
 func ForwardSignals(c *exec.Cmd) func() {
 	sigCh := make(chan os.Signal, 4)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
@@ -24,9 +37,21 @@ func ForwardSignals(c *exec.Cmd) func() {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+		intCount := 0
 		for {
 			select {
 			case sig := <-sigCh:
+				if sig == syscall.SIGINT {
+					intCount++
+					if intCount >= 2 {
+						fmt.Fprintln(os.Stderr,
+							"defrost: second SIGINT received; killing child and force-quitting")
+						if c.Process != nil {
+							_ = c.Process.Kill()
+						}
+						os.Exit(130)
+					}
+				}
 				if c.Process != nil {
 					_ = c.Process.Signal(sig)
 				}

--- a/internal/runner/exec_test.go
+++ b/internal/runner/exec_test.go
@@ -1,0 +1,50 @@
+package runner
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+)
+
+func TestRunChild_PropagatesExitCode(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	c := exec.Command("sh", "-c", "exit 7")
+	// Discard child stdio so the test runner's output stays clean.
+	var buf bytes.Buffer
+	c.Stdout = &buf
+	c.Stderr = &buf
+	code, err := RunChild(c)
+	if err != nil {
+		t.Fatalf("RunChild err: %v", err)
+	}
+	if code != 7 {
+		t.Errorf("got code %d, want 7", code)
+	}
+}
+
+func TestRunChild_BinaryNotFound(t *testing.T) {
+	c := exec.Command("/nonexistent/defrost-test-binary")
+	code, err := RunChild(c)
+	if err == nil {
+		t.Fatalf("expected error for missing binary, got code=%d", code)
+	}
+	if code != -1 {
+		t.Errorf("got code %d, want -1 for start failure", code)
+	}
+}
+
+func TestRunChild_ZeroExit(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	c := exec.Command("sh", "-c", "exit 0")
+	var buf bytes.Buffer
+	c.Stdout = &buf
+	c.Stderr = &buf
+	code, err := RunChild(c)
+	if err != nil || code != 0 {
+		t.Fatalf("got (%d, %v), want (0, nil)", code, err)
+	}
+}

--- a/internal/runner/passthrough/adapter.go
+++ b/internal/runner/passthrough/adapter.go
@@ -1,0 +1,37 @@
+package passthrough
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/bjk95/defrost/internal/models"
+	"github.com/bjk95/defrost/internal/runner"
+)
+
+// Adapter is the universal fallback. It matches any non-empty argv and
+// executes cmd verbatim with stdio + signals wired through, returning the
+// child's exit code and no test results.
+//
+// Register last in the registry so framework-specific adapters win when
+// they recognise the invocation. The point is that `defrost exec <cmd>`
+// always runs the user's command — when no specialised adapter matches,
+// per-test results are missing but the run itself still happens, and the
+// run-level record (commit, exit code, OTel metrics emitted by the child)
+// is still persisted.
+type Adapter struct{}
+
+func (Adapter) Matches(cmd []string) bool { return len(cmd) > 0 }
+
+func (Adapter) Run(cmd []string) ([]models.TestResult, int) {
+	fmt.Fprintf(os.Stderr,
+		"defrost: no test-framework adapter matched %q; running passthrough (no per-test results will be recorded)\n",
+		cmd[0])
+	c := exec.Command(cmd[0], cmd[1:]...)
+	code, err := runner.RunChild(c)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "defrost:", err)
+		return nil, 1
+	}
+	return nil, code
+}

--- a/internal/runner/passthrough/adapter_test.go
+++ b/internal/runner/passthrough/adapter_test.go
@@ -1,0 +1,47 @@
+package passthrough
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestMatches_AnyNonEmpty(t *testing.T) {
+	cases := []struct {
+		cmd  []string
+		want bool
+	}{
+		{nil, false},
+		{[]string{}, false},
+		{[]string{"true"}, true},
+		{[]string{"go", "test"}, true},
+		{[]string{"some-arbitrary-tool", "--flag"}, true},
+	}
+	for _, tc := range cases {
+		if got := (Adapter{}).Matches(tc.cmd); got != tc.want {
+			t.Errorf("Matches(%v) = %v, want %v", tc.cmd, got, tc.want)
+		}
+	}
+}
+
+func TestRun_PropagatesExitCode(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	results, code := (Adapter{}).Run([]string{"sh", "-c", "exit 3"})
+	if results != nil {
+		t.Errorf("expected no results, got %v", results)
+	}
+	if code != 3 {
+		t.Errorf("got code %d, want 3", code)
+	}
+}
+
+func TestRun_BinaryNotFoundReturnsOne(t *testing.T) {
+	results, code := (Adapter{}).Run([]string{"/nonexistent/defrost-test-binary"})
+	if results != nil {
+		t.Errorf("expected no results, got %v", results)
+	}
+	if code != 1 {
+		t.Errorf("got code %d, want 1 (start failure surfaces as 1)", code)
+	}
+}


### PR DESCRIPTION
## Summary

Make `defrost exec <cmd>` always run the user's command. The previous behaviour failed closed in two ways that blocked builds for reasons unrelated to the tests themselves:

1. **Unrecognised command → exit 2.** Anything that wasn't `go test`, `pytest`, or jest in one of a handful of supported shapes refused to run.
2. **Missing/unparseable output file → exit 1, overriding the child's exit code.** A jest panic that failed to write the JSON file would surface as `1` even if the user's actual test exit was `137` (OOM kill) or `5` (no tests collected, pytest).

This PR is the "wrap any run command and have it just work" guarantee. Robustness #2 from the planning thread (broader match flexibility — env-var prefixes, shell wrappers, monorepo workspace forms, config-file conflicts) is tracked separately in #12.

## Changes

- **`internal/runner.RunChild` + `ForwardSignals`** — small helper that wires stdio and forwards SIGINT/SIGTERM/SIGHUP/SIGQUIT to the child, so `kill -TERM defrost` no longer leaves the child orphaned.
- **`internal/runner/passthrough`** — universal fallback adapter; matches any non-empty argv and execs verbatim. Registered last in `HandleExecution` so framework-specific adapters keep first crack.
- **jest / pytest** — preserve child exit code when the output file is missing/empty/unparseable; record the run with no per-test results instead of overwriting the signal.
- **jest** — `--json`, `--watch`, and non-direct script-shape conditions now passthrough with a warning instead of refusing with exit 2.
- **pytest** — `--junitxml` collision now passthroughs with a warning.
- **go executor** — pipe stdin through to the child and install signal forwarding alongside its existing stdout-pipe parsing path.

## Test plan

- [x] `go test ./...` — all packages pass (`internal/runner`, `internal/runner/passthrough`, `internal/golang`, `internal/javascript/jest`, `internal/python/pytest`, top-level `defrost`).
- [x] `go vet ./...` clean.
- [x] New unit tests:
  - `RunChild` propagates child exit code and surfaces start failures.
  - Passthrough adapter matches any non-empty argv and propagates exit codes.
  - jest/pytest `parseOrPreserve` preserves the child exit code on missing, empty, or malformed output files.
  - `HandleExecution` falls through to passthrough for unrecognised commands.
- [ ] Manual smoke: run `defrost exec sh -c "exit 9"` end-to-end and confirm exit 9 + warning.
- [ ] Manual smoke: SIGTERM the parent during a long-running pytest; confirm child receives SIGTERM and exits.

Refs #12.

https://claude.ai/code/session_01L5rsRBqRUCVzDvAEEdvoAA

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5rsRBqRUCVzDvAEEdvoAA)_