### PR TITLE
feat(exec): auto-emit run duration gauge

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -126,6 +126,7 @@ func execWith(a runner.Adapter, cmd []string, opts ExecOpts) int {
 	// when, what commit, what exit code — the runs you most want to
 	// debug are precisely the ones with no per-test data.
 	if opts.Persist && !persistFailed {
+		metrics = append(metrics, persist.RunDurationMetric(run, cmd, opts.RepoDir, time.Now()))
 		if err := persistRun(pOpts, run, results, metrics, code); err != nil {
 			fmt.Fprintln(os.Stderr, "persist: failed:", err)
 			// A persist failure should surface even when the test command

--- a/internal/persist/persist.go
+++ b/internal/persist/persist.go
@@ -257,6 +257,39 @@ func NewRootSpan(run models.RunContext) *tracepb.Span {
 	}
 }
 
+// RunDurationMetric returns the auto-emitted gauge that records the
+// wall-clock duration of one defrost exec invocation, in milliseconds.
+// The metric name embeds the run's path-from-repo-root and the wrapped
+// command so each invocation site has its own time series.
+func RunDurationMetric(run models.RunContext, cmd []string, repoDir string, end time.Time) *metricspb.Metric {
+	durationMs := float64(end.UnixNano()-run.StartTimeUnixNano) / 1e6
+	return &metricspb.Metric{
+		Name:        "defrost.run." + runFQN(repoDir, cmd),
+		Description: "Wall-clock duration of one defrost exec invocation.",
+		Unit:        "ms",
+		Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{
+			DataPoints: []*metricspb.NumberDataPoint{{
+				StartTimeUnixNano: uint64(run.StartTimeUnixNano),
+				TimeUnixNano:      uint64(end.UnixNano()),
+				Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: durationMs},
+			}},
+		}},
+	}
+}
+
+// runFQN builds the fully qualified run identifier embedded in the
+// duration metric name: "<path-from-repo-root>¬<space-joined cmd>" when
+// invoked from a subdirectory, or just the command when invoked at the
+// repo root (or when the prefix lookup fails).
+func runFQN(repoDir string, cmd []string) string {
+	joined := strings.Join(cmd, " ")
+	prefix, err := runGit(repoDir, "rev-parse", "--show-prefix")
+	if err != nil || prefix == "" {
+		return joined
+	}
+	return strings.TrimSuffix(prefix, "/") + "¬" + joined
+}
+
 // WrapSpansInResource constructs one *tracepb.ResourceSpans per span,
 // each carrying the same Resource. This is the storage shape: each line
 // in traces/<name>.ndjson is one ResourceSpans with a single Span.

--- a/internal/persist/persist_test.go
+++ b/internal/persist/persist_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
@@ -433,6 +434,65 @@ func TestLoadAll_NoBranch_ReturnsEmpty(t *testing.T) {
 	}
 	if len(byEncodedName) != 0 {
 		t.Errorf("expected 0 test groups, got %d", len(byEncodedName))
+	}
+}
+
+func TestRunDurationMetric(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repoDir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", repoDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	sub := filepath.Join(repoDir, "subpkg")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	startNs := int64(1_000_000_000)
+	run := models.RunContext{StartTimeUnixNano: startNs}
+	end := time.Unix(0, startNs+1_500_000_000) // +1.5s
+
+	cases := []struct {
+		name    string
+		repoDir string
+		want    string
+	}{
+		{"root", repoDir, "defrost.run.go test ./..."},
+		{"subdir", sub, "defrost.run.subpkg¬go test ./..."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := RunDurationMetric(run, []string{"go", "test", "./..."}, tc.repoDir, end)
+			if m.Name != tc.want {
+				t.Errorf("name: got %q want %q", m.Name, tc.want)
+			}
+			if m.Unit != "ms" {
+				t.Errorf("unit: got %q want %q", m.Unit, "ms")
+			}
+			g, ok := m.Data.(*metricspb.Metric_Gauge)
+			if !ok {
+				t.Fatalf("data: got %T want *Metric_Gauge", m.Data)
+			}
+			if len(g.Gauge.DataPoints) != 1 {
+				t.Fatalf("data points: got %d want 1", len(g.Gauge.DataPoints))
+			}
+			dp := g.Gauge.DataPoints[0]
+			dv, ok := dp.Value.(*metricspb.NumberDataPoint_AsDouble)
+			if !ok {
+				t.Fatalf("value: got %T want AsDouble", dp.Value)
+			}
+			if dv.AsDouble != 1500.0 {
+				t.Errorf("value ms: got %v want 1500", dv.AsDouble)
+			}
+			if dp.StartTimeUnixNano != uint64(startNs) {
+				t.Errorf("start nano: got %d want %d", dp.StartTimeUnixNano, startNs)
+			}
+			if dp.TimeUnixNano != uint64(end.UnixNano()) {
+				t.Errorf("end nano: got %d want %d", dp.TimeUnixNano, end.UnixNano())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Every persisted `defrost exec` invocation now emits a default `defrost.run.<FQN>` gauge metric recording the run's wall-clock duration in milliseconds — no instrumentation required from the user.

The metric name embeds a fully-qualified run identifier so each invocation site gets its own time series:

- Repo root: `defrost.run.go test ./...`
- Subdirectory: `defrost.run.subpkg¬go test ./...` (path-from-repo-root, `¬` separator, space-joined cmd)

Path-from-repo-root is resolved with `git rev-parse --show-prefix`. On error or empty prefix it falls back to just the joined command.

## What changed

- `internal/persist/persist.go` — new `RunDurationMetric(...)` builds a single-data-point gauge in `ms` (double); private `runFQN` builds the name suffix.
- `exec.go` — one-line append into the existing `metrics` slice immediately before `persistRun`, gated by the same `opts.Persist && !persistFailed` check, so the metric is skipped under `--no-persist` or when persistence has already failed.
- `internal/persist/persist_test.go` — focused unit test with subtests for the root and subdir cases asserting name, unit (`ms`), gauge shape, double value (1500 ms), and start/end nanos.

## Why

Run duration is the most universally useful default metric and was previously invisible unless the wrapped command emitted its own latency telemetry.

## Notes for review

- Wall-clock window: `run.StartTimeUnixNano` → `time.Now()` immediately before `persistRun`. Includes the OTLP drain grace; excludes the persist call itself.
- Filename safety is already handled — `EncodeName` URL-escapes the metric name, so `¬`, spaces, and `/` in the FQN don't escape into directory structure on the data branch.
- Cardinality: each unique `(path, cmd)` becomes its own metric file under `metrics/`. That matches the user's requested shape.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] New `TestRunDurationMetric` covers root + subdir name shape, unit, gauge type, double value, and timestamp wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)