### PR TITLE
feat(eval): Inspect AI adapter (Role A runner)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -350,7 +350,11 @@ jobs:
         run: |
           set -o pipefail
           cd examples/inspect
-          ../../defrost exec inspect eval task.py --model none 2>&1 | tee out.txt
+          # --display plain disables Inspect's Rich-based progress UI so the
+          # defrost summary line lands at column 0 in out.txt (Rich's
+          # animated progress bars otherwise leave whitespace runs that
+          # prevent the assertion below from anchoring on ^defrost:).
+          ../../defrost exec inspect eval task.py --model none --display plain 2>&1 | tee out.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -359,7 +363,9 @@ jobs:
           # Inspect AI exits 0 even when samples fail scoring, so the
           # regression-detection signal is the pass/fail breakdown rather
           # than the exit code. Expected: 2 pass, 2 fail, 0 skip = 4 total.
-          line=$(grep -E '^defrost: results:' examples/inspect/out.txt | tail -1)
+          # Strip leading whitespace defensively in case Rich progress output
+          # leaks through despite --display plain.
+          line=$(grep -E 'defrost: results:' examples/inspect/out.txt | tail -1 | sed 's/^[[:space:]]*//')
           if [ -z "$line" ]; then
             echo "FAIL: no 'defrost: results:' line found"
             cat examples/inspect/out.txt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -342,7 +342,6 @@ jobs:
           ./defrost suppress add \
             'examples/inspect¬task="capital_cities",sample="germany-fail"' \
             'examples/inspect¬task="capital_cities",sample="empty-fail"'
-          ./defrost suppress list
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -308,3 +308,75 @@ jobs:
         with:
           name: promptfoo-out
           path: examples/promptfoo/out.txt
+
+  inspect:
+    name: inspect-ai example
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install inspect-ai
+        run: pip install -r examples/inspect/requirements.txt
+
+      - name: Build defrost
+        run: go build -o defrost .
+
+      - name: Configure git auth for defrost persist
+        run: |
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Suppress known-intentional failures (dogfood the suppression flow)
+        run: |
+          set -e
+          ./defrost suppress add \
+            'examples/inspect¬task="capital_cities",sample="germany-fail"' \
+            'examples/inspect¬task="capital_cities",sample="empty-fail"'
+          ./defrost suppress list
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run defrost against examples/inspect
+        run: |
+          set -o pipefail
+          cd examples/inspect
+          ../../defrost exec inspect eval task.py --model none 2>&1 | tee out.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert result count matches expected
+        run: |
+          # Inspect AI exits 0 even when samples fail scoring, so the
+          # regression-detection signal is the pass/fail breakdown rather
+          # than the exit code. Expected: 2 pass, 2 fail, 0 skip = 4 total.
+          line=$(grep -E '^defrost: results:' examples/inspect/out.txt | tail -1)
+          if [ -z "$line" ]; then
+            echo "FAIL: no 'defrost: results:' line found"
+            cat examples/inspect/out.txt
+            exit 1
+          fi
+          echo "summary: $line"
+          counts=$(echo "$line" | sed -E 's/^defrost: results: ([0-9]+) pass, ([0-9]+) fail, ([0-9]+) skip$/\1 \2 \3/')
+          set -- $counts
+          if [ "$1" -ne 2 ] || [ "$2" -ne 2 ] || [ "$3" -ne 0 ]; then
+            echo "FAIL: expected 2 pass / 2 fail / 0 skip, got $1/$2/$3"
+            cat examples/inspect/out.txt
+            exit 1
+          fi
+
+      - name: Upload defrost output for debugging
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inspect-out
+          path: examples/inspect/out.txt

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ docs/superpowers/
 
 # OS noise
 .DS_Store
+
+# Python bytecode (e.g. examples/inspect/__pycache__)
+__pycache__/
+*.pyc

--- a/examples/inspect/README.md
+++ b/examples/inspect/README.md
@@ -1,0 +1,20 @@
+# inspect-ai example
+
+Defrost-instrumented Inspect AI eval that dogfoods the adapter. Uses a
+deterministic mock solver (`mock_solver` in `task.py`) that reads each
+sample's `metadata.mock_answer` and reports it as the model output, so the
+eval runs in CI with predictable pass/fail outcomes and **no LLM API calls**.
+
+The dogfood ships 4 samples (2 pass, 2 intentional fail) all scored by
+Inspect's built-in `match()` scorer.
+
+```sh
+# from this directory
+pip install inspect-ai
+inspect eval task.py                  # bare inspect
+defrost exec inspect eval task.py     # via defrost
+```
+
+To run against a real LLM, drop `mock_solver()` from the `Task` definition,
+add a real `Solver` (or omit `solver=` to use Inspect's default `generate()`),
+and pass `--model openai/gpt-4o` (or similar) on the command line.

--- a/examples/inspect/requirements.txt
+++ b/examples/inspect/requirements.txt
@@ -1,0 +1,1 @@
+inspect-ai

--- a/examples/inspect/task.py
+++ b/examples/inspect/task.py
@@ -1,0 +1,76 @@
+"""Defrost dogfood for the Inspect AI adapter.
+
+Uses a deterministic mock solver that returns whatever the sample's metadata
+says, plus a custom numeric scorer (`numeric_match`) so each scored sample
+emits an `eval.numeric_match` metric. Inspect's built-in `match()` returns
+Letter values (`"C"`/`"I"`) which the v1 adapter skips with a warning -- the
+custom scorer here keeps the dogfood exercising the metric path end-to-end.
+"""
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import Score, Target, mean, scorer, stderr
+from inspect_ai.solver import Generate, TaskState, solver
+
+
+@solver
+def mock_solver():
+    """Return the canned answer carried in each sample's metadata."""
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        state.output.completion = state.metadata.get("mock_answer", "")
+        return state
+
+    return solve
+
+
+@scorer(metrics=[mean(), stderr()])
+def numeric_match():
+    """Case-insensitive exact-match returning 1.0 / 0.0 (numeric)."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        completion = state.output.completion.strip().lower()
+        expected = target.text.strip().lower()
+        if completion == expected:
+            return Score(value=1.0, answer=state.output.completion, explanation="match")
+        return Score(value=0.0, answer=state.output.completion, explanation="mismatch")
+
+    return score
+
+
+@task
+def capital_cities():
+    return Task(
+        dataset=[
+            # passes: mock answer matches target.
+            Sample(
+                id="france-pass",
+                input="Capital of France?",
+                target="Paris",
+                metadata={"mock_answer": "Paris"},
+            ),
+            # passes: case-insensitive exact match.
+            Sample(
+                id="italy-pass",
+                input="Capital of Italy?",
+                target="Rome",
+                metadata={"mock_answer": "rome"},
+            ),
+            # intentional fail: mock answer diverges from target.
+            Sample(
+                id="germany-fail",
+                input="Capital of Germany?",
+                target="Berlin",
+                metadata={"mock_answer": "London"},
+            ),
+            # intentional fail: empty answer.
+            Sample(
+                id="empty-fail",
+                input="Capital of Spain?",
+                target="Madrid",
+                metadata={"mock_answer": ""},
+            ),
+        ],
+        solver=mock_solver(),
+        scorer=numeric_match(),
+    )

--- a/exec.go
+++ b/exec.go
@@ -10,6 +10,7 @@ import (
 	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 
+	"github.com/bjk95/defrost/internal/eval/inspect"
 	"github.com/bjk95/defrost/internal/eval/promptfoo"
 	"github.com/bjk95/defrost/internal/golang"
 	"github.com/bjk95/defrost/internal/javascript/jest"
@@ -46,6 +47,10 @@ func HandleExecution(cmd []string, opts ExecOpts) int {
 
 	reg := runner.NewRegistry()
 	reg.Register(golang.Adapter{})
+	// inspect registers before pytest because both can match `<tool> run <bin>`
+	// shapes, and inspect's matcher is the stricter one (it requires the
+	// `eval` subcommand). Strict matchers go first.
+	reg.Register(&inspect.Adapter{})
 	reg.Register(pytest.Adapter{})
 	// promptfoo registers before jest because jest's yarn-script matcher reads
 	// ./package.json and would claim `yarn promptfoo eval` when scripts.promptfoo

--- a/internal/eval/inspect/adapter.go
+++ b/internal/eval/inspect/adapter.go
@@ -1,0 +1,162 @@
+package inspect
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+
+	"github.com/bjk95/defrost/internal/models"
+	"github.com/bjk95/defrost/internal/runner"
+)
+
+// Adapter implements runner.Adapter for `inspect eval` invocations. The
+// adapter recognises the direct binary, the `python -m inspect_ai eval` form,
+// and tool-runner forms (poetry/uv/pipenv run inspect eval).
+type Adapter struct{}
+
+var pythonRe = regexp.MustCompile(`^python(3(\.\d+)?)?$`)
+
+var toolRunners = map[string]bool{
+	"poetry": true,
+	"uv":     true,
+	"pipenv": true,
+}
+
+func (a *Adapter) Matches(cmd []string) bool {
+	if len(cmd) == 0 {
+		return false
+	}
+	// Direct: inspect eval ... or /path/to/inspect eval ...
+	if filepath.Base(cmd[0]) == "inspect" {
+		return len(cmd) >= 2 && cmd[1] == "eval"
+	}
+	// python -m inspect_ai eval ...
+	if pythonRe.MatchString(cmd[0]) && len(cmd) >= 4 &&
+		cmd[1] == "-m" && cmd[2] == "inspect_ai" && cmd[3] == "eval" {
+		return true
+	}
+	// poetry run inspect eval ... / uv run inspect eval ...
+	if toolRunners[cmd[0]] && len(cmd) >= 4 &&
+		cmd[1] == "run" && filepath.Base(cmd[2]) == "inspect" && cmd[3] == "eval" {
+		return true
+	}
+	return false
+}
+
+// hasFlag reports whether args contains either `--flag <v>` or
+// `--flag=<v>`. Used to detect user-supplied --log-dir / --log-format that
+// would conflict with defrost's auto-injection.
+func hasFlag(args []string, flag string) bool {
+	prefix := flag + "="
+	for _, a := range args {
+		if a == flag || strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildArgs returns the args slice (excluding cmd[0]) with `--log-dir
+// <tempDir> --log-format json` appended. Caller must have verified the user
+// did not already supply these flags.
+func buildArgs(cmd []string, tempDir string) []string {
+	rest := append([]string{}, cmd[1:]...)
+	return append(rest, "--log-dir", tempDir, "--log-format", "json")
+}
+
+// passthroughRun executes cmd verbatim with stdio and signals wired through,
+// returning the child exit code without parsing any results. Used when the
+// user supplied --log-dir or --log-format and defrost can't safely override.
+func passthroughRun(cmd []string) ([]models.TestResult, []*metricspb.Metric, int) {
+	c := exec.Command(cmd[0], cmd[1:]...)
+	code, err := runner.RunChild(c)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "defrost:", err)
+		return nil, nil, 1
+	}
+	return nil, nil, code
+}
+
+func (a *Adapter) Run(cmd []string) ([]models.TestResult, []*metricspb.Metric, int) {
+	if len(cmd) == 0 {
+		return nil, nil, 2
+	}
+
+	if hasFlag(cmd[1:], "--log-dir") || hasFlag(cmd[1:], "--log-format") {
+		fmt.Fprintln(os.Stderr,
+			"defrost: inspect --log-dir / --log-format present in argv; running passthrough (no per-test results will be recorded)")
+		return passthroughRun(cmd)
+	}
+
+	tempDir, err := os.MkdirTemp("", "defrost-inspect-*")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "defrost:", err)
+		return nil, nil, 1
+	}
+	defer os.RemoveAll(tempDir)
+
+	args := buildArgs(cmd, tempDir)
+	child := exec.Command(cmd[0], args...)
+	exitCode, err := runner.RunChild(child)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "defrost:", err)
+		return nil, nil, 1
+	}
+
+	results, metrics, parseErr := parseLogDir(tempDir)
+	if parseErr != nil {
+		fmt.Fprintln(os.Stderr, "defrost:", parseErr)
+		if exitCode == 0 {
+			exitCode = 1
+		}
+		return nil, nil, exitCode
+	}
+	if len(results) == 0 {
+		fmt.Fprintln(os.Stderr,
+			"defrost: inspect produced no JSON log files in", tempDir,
+			"(child exit", exitCode, ")")
+		if exitCode == 0 {
+			exitCode = 1
+		}
+		return nil, nil, exitCode
+	}
+
+	runner.ApplyRepoPrefix(results)
+	return results, metrics, exitCode
+}
+
+// parseLogDir scans dir for *.json files (Inspect's --log-format=json output)
+// and parses each one. Per-file decode failures are logged and skipped so a
+// single corrupt file doesn't drop the whole run. Returns error only on
+// directory listing failure.
+func parseLogDir(dir string) ([]models.TestResult, []*metricspb.Metric, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("glob inspect log dir: %w", err)
+	}
+	var (
+		allTests   []models.TestResult
+		allMetrics []*metricspb.Metric
+	)
+	for _, path := range matches {
+		f, err := os.Open(path)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "defrost: inspect: open", path, ":", err)
+			continue
+		}
+		tests, metrics, parseErr := ParseFile(f)
+		f.Close()
+		if parseErr != nil {
+			fmt.Fprintln(os.Stderr, "defrost: inspect: parse", path, ":", parseErr)
+			continue
+		}
+		allTests = append(allTests, tests...)
+		allMetrics = append(allMetrics, metrics...)
+	}
+	return allTests, allMetrics, nil
+}

--- a/internal/eval/inspect/adapter_test.go
+++ b/internal/eval/inspect/adapter_test.go
@@ -1,0 +1,273 @@
+package inspect
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMatches(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  []string
+		want bool
+	}{
+		{"direct", []string{"inspect", "eval", "task.py"}, true},
+		{"direct with model", []string{"inspect", "eval", "task.py", "--model", "openai/gpt-4o"}, true},
+		{"direct with extra flags", []string{"inspect", "eval", "task.py", "--limit", "10", "--epochs", "2"}, true},
+		{"absolute path inspect", []string{"/usr/local/bin/inspect", "eval", "task.py"}, true},
+		{"python -m inspect_ai eval", []string{"python", "-m", "inspect_ai", "eval", "task.py"}, true},
+		{"python3 -m inspect_ai eval", []string{"python3", "-m", "inspect_ai", "eval", "task.py"}, true},
+		{"python3.12 -m inspect_ai eval", []string{"python3.12", "-m", "inspect_ai", "eval", "task.py"}, true},
+		{"poetry run inspect eval", []string{"poetry", "run", "inspect", "eval", "task.py"}, true},
+		{"uv run inspect eval", []string{"uv", "run", "inspect", "eval", "task.py"}, true},
+		{"pipenv run inspect eval", []string{"pipenv", "run", "inspect", "eval", "task.py"}, true},
+		{"poetry run absolute inspect", []string{"poetry", "run", "/usr/bin/inspect", "eval", "task.py"}, true},
+		{"missing eval subcommand", []string{"inspect"}, false},
+		{"different subcommand", []string{"inspect", "view"}, false},
+		{"different subcommand inspect score", []string{"inspect", "score"}, false},
+		{"unrelated cmd", []string{"pytest"}, false},
+		{"empty", []string{}, false},
+		{"echo arg-mistake", []string{"echo", "inspect", "eval"}, false},
+		{"sh -c inspect eval", []string{"sh", "-c", "inspect eval task.py"}, false},
+		{"python -m wrong module", []string{"python", "-m", "pytest", "eval"}, false},
+		{"python -m inspect_ai wrong subcommand", []string{"python", "-m", "inspect_ai", "view"}, false},
+		{"poetry run wrong tool", []string{"poetry", "run", "pytest"}, false},
+		{"poetry run inspect missing eval", []string{"poetry", "run", "inspect"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Adapter{}
+			got := a.Matches(tc.cmd)
+			if got != tc.want {
+				t.Fatalf("Matches(%v) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasFlag(t *testing.T) {
+	cases := []struct {
+		args []string
+		flag string
+		want bool
+	}{
+		{[]string{"eval", "task.py"}, "--log-dir", false},
+		{[]string{"eval", "task.py", "--log-dir", "/tmp/x"}, "--log-dir", true},
+		{[]string{"eval", "task.py", "--log-dir=/tmp/x"}, "--log-dir", true},
+		{[]string{"eval", "task.py", "--log-format", "json"}, "--log-format", true},
+		{[]string{"eval", "task.py", "--log-format=json"}, "--log-format", true},
+		{[]string{"eval", "task.py", "--model", "gpt-4o"}, "--log-dir", false},
+	}
+	for _, tc := range cases {
+		got := hasFlag(tc.args, tc.flag)
+		if got != tc.want {
+			t.Errorf("hasFlag(%v, %q) = %v, want %v", tc.args, tc.flag, got, tc.want)
+		}
+	}
+}
+
+func TestBuildArgs(t *testing.T) {
+	args := buildArgs([]string{"inspect", "eval", "task.py", "--model", "openai/gpt-4o"}, "/tmp/logs")
+	want := []string{"eval", "task.py", "--model", "openai/gpt-4o", "--log-dir", "/tmp/logs", "--log-format", "json"}
+	if !equalSlices(args, want) {
+		t.Fatalf("buildArgs = %v, want %v", args, want)
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// fakeChildScript writes a small bash script that reads --log-dir from its
+// args and copies the named fixture there as <task>.json. Used to stub out
+// `inspect eval` in Run tests.
+func fakeChildScript(t *testing.T, fixtures ...string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-child shell script is bash-only")
+	}
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "fake-inspect")
+	body := `#!/usr/bin/env bash
+set -e
+log_dir=""
+for ((i=1;i<=$#;i++)); do
+    a="${!i}"
+    if [[ "$a" == "--log-dir" ]]; then
+        n=$((i+1))
+        log_dir="${!n}"
+        break
+    elif [[ "$a" == --log-dir=* ]]; then
+        log_dir="${a#*=}"
+        break
+    fi
+done
+if [[ -z "$log_dir" ]]; then
+    echo "fake-inspect: no --log-dir flag" >&2
+    exit 2
+fi
+`
+	for i, fx := range fixtures {
+		fixtureSrc, err := filepath.Abs(filepath.Join("testdata", fx))
+		if err != nil {
+			t.Fatalf("abs: %v", err)
+		}
+		body += "cp \"" + fixtureSrc + "\" \"$log_dir/log_" + itoa(i) + ".json\"\n"
+	}
+	if err := os.WriteFile(scriptPath, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake-inspect: %v", err)
+	}
+	abs, err := filepath.Abs(scriptPath)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	return abs
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf []byte
+	for n > 0 {
+		buf = append([]byte{byte('0' + n%10)}, buf...)
+		n /= 10
+	}
+	return string(buf)
+}
+
+func TestRunHappyPath(t *testing.T) {
+	bin := fakeChildScript(t, "smoke.json")
+	a := &Adapter{}
+	tests, metrics, code := a.Run([]string{bin, "eval", "task.py"})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+	if len(tests) != 2 {
+		t.Fatalf("expected 2 tests, got %d", len(tests))
+	}
+	if len(metrics) != 2 {
+		t.Fatalf("expected 2 metrics, got %d", len(metrics))
+	}
+	if metrics[0].Name != "eval.match" {
+		t.Fatalf("expected eval.match, got %q", metrics[0].Name)
+	}
+}
+
+func TestRunMultipleLogFiles(t *testing.T) {
+	// Inspect can write multiple log files when given multiple tasks; the
+	// adapter must aggregate results across all *.json files in the log dir.
+	bin := fakeChildScript(t, "smoke.json", "multi_scorer.json")
+	a := &Adapter{}
+	tests, metrics, code := a.Run([]string{bin, "eval", "task1.py", "task2.py"})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+	if len(tests) != 3 {
+		t.Fatalf("expected 3 tests (2 + 1), got %d", len(tests))
+	}
+	if len(metrics) != 4 {
+		t.Fatalf("expected 4 metrics (2 + 2), got %d", len(metrics))
+	}
+}
+
+func TestRunFailingChildPropagatesExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-child shell script is bash-only")
+	}
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "fake-fail")
+	body := `#!/usr/bin/env bash
+exit 7
+`
+	if err := os.WriteFile(scriptPath, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake-fail: %v", err)
+	}
+	abs, _ := filepath.Abs(scriptPath)
+	a := &Adapter{}
+	_, _, code := a.Run([]string{abs, "eval", "task.py"})
+	if code != 7 {
+		t.Fatalf("expected exit 7, got %d", code)
+	}
+}
+
+func TestRunPassthroughOnUserLogDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-child shell script is bash-only")
+	}
+	// Fake child that exits 0 immediately. With user-supplied --log-dir
+	// defrost must not parse anything and must propagate the child exit.
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "fake-noop")
+	if err := os.WriteFile(scriptPath, []byte("#!/usr/bin/env bash\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	abs, _ := filepath.Abs(scriptPath)
+
+	a := &Adapter{}
+	tests, metrics, code := a.Run([]string{abs, "eval", "task.py", "--log-dir", "/tmp/userlogs"})
+	if code != 0 {
+		t.Fatalf("expected exit 0 (passthrough propagates child exit), got %d", code)
+	}
+	if len(tests) != 0 || len(metrics) != 0 {
+		t.Fatalf("expected no results in passthrough mode, got %d tests / %d metrics", len(tests), len(metrics))
+	}
+}
+
+func TestRunPassthroughOnUserLogFormat(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-child shell script is bash-only")
+	}
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "fake-noop")
+	if err := os.WriteFile(scriptPath, []byte("#!/usr/bin/env bash\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	abs, _ := filepath.Abs(scriptPath)
+
+	a := &Adapter{}
+	tests, metrics, code := a.Run([]string{abs, "eval", "task.py", "--log-format=eval"})
+	if code != 0 {
+		t.Fatalf("expected exit 0 (passthrough), got %d", code)
+	}
+	if len(tests) != 0 || len(metrics) != 0 {
+		t.Fatalf("expected no results in passthrough mode, got %d tests / %d metrics", len(tests), len(metrics))
+	}
+}
+
+func TestRunChildSucceededButNoLogsBumpsExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-child shell script is bash-only")
+	}
+	// Child exits 0 but writes no JSON. Defrost must surface this as
+	// non-zero so CI can't silently report success on a broken run.
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "fake-noop")
+	if err := os.WriteFile(scriptPath, []byte("#!/usr/bin/env bash\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake-noop: %v", err)
+	}
+	abs, _ := filepath.Abs(scriptPath)
+	a := &Adapter{}
+	_, _, code := a.Run([]string{abs, "eval", "task.py"})
+	if code != 1 {
+		t.Fatalf("expected exit 1 (defrost-internal floor), got %d", code)
+	}
+}
+
+func TestRunEmpty(t *testing.T) {
+	a := &Adapter{}
+	_, _, code := a.Run(nil)
+	if code != 2 {
+		t.Fatalf("expected exit 2, got %d", code)
+	}
+}

--- a/internal/eval/inspect/parser.go
+++ b/internal/eval/inspect/parser.go
@@ -1,0 +1,216 @@
+package inspect
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+
+	"github.com/bjk95/defrost/internal/models"
+)
+
+// passThreshold is the cutoff a sample's numeric scorer must clear for the
+// sample to count as passed. Inspect AI's per-sample JSON does not carry the
+// scorer's threshold, and `match()`/binary scorers emit 0.0 or 1.0, so 0.5 is
+// the only value that classifies both binary and continuous scores correctly
+// without external configuration.
+const passThreshold = 0.5
+
+// inspectDoc is the subset of an Inspect AI JSON log we read.
+type inspectDoc struct {
+	Eval    inspectEval     `json:"eval"`
+	Samples []inspectSample `json:"samples"`
+}
+
+type inspectEval struct {
+	Task  string `json:"task"`
+	Model string `json:"model"`
+}
+
+type inspectSample struct {
+	ID     any                     `json:"id"`
+	Output inspectOutput           `json:"output"`
+	Scores map[string]inspectScore `json:"scores"`
+}
+
+type inspectOutput struct {
+	Completion string `json:"completion"`
+}
+
+type inspectScore struct {
+	Value       any    `json:"value"`
+	Answer      string `json:"answer"`
+	Explanation string `json:"explanation"`
+}
+
+// ParseFile reads a single Inspect AI JSON log and emits one TestResult per
+// sample plus one *metricspb.Metric per (sample, numeric scorer) pair. Scorers
+// whose value is non-numeric (Letter "C"/"I", compound objects) are skipped
+// with a stderr warning. Returns nil/nil/error only on JSON decode failure.
+func ParseFile(r io.Reader) ([]models.TestResult, []*metricspb.Metric, error) {
+	var doc inspectDoc
+	if err := json.NewDecoder(r).Decode(&doc); err != nil {
+		return nil, nil, fmt.Errorf("parse inspect json: %w", err)
+	}
+	now := uint64(time.Now().UnixNano())
+	var (
+		tests   []models.TestResult
+		metrics []*metricspb.Metric
+	)
+	for _, s := range doc.Samples {
+		tr, m := mapSample(s, doc.Eval.Task, doc.Eval.Model, now)
+		tests = append(tests, tr)
+		metrics = append(metrics, m...)
+	}
+	return tests, metrics, nil
+}
+
+// mapSample produces the TestResult and per-scorer metrics for a single
+// sample. Pass/fail is the conjunction of all numeric scorers clearing
+// passThreshold; a sample with no numeric scorers is treated as passed (it
+// ran without scoring failures).
+func mapSample(s inspectSample, task, model string, now uint64) (models.TestResult, []*metricspb.Metric) {
+	caseName := sampleCaseName(s.ID, task)
+
+	scorerNames := make([]string, 0, len(s.Scores))
+	for k := range s.Scores {
+		scorerNames = append(scorerNames, k)
+	}
+	sort.Strings(scorerNames)
+
+	pass := true
+	hasNumeric := false
+	var metrics []*metricspb.Metric
+	for _, name := range scorerNames {
+		score := s.Scores[name]
+		v, ok := numericScore(score.Value)
+		if !ok {
+			fmt.Fprintf(os.Stderr,
+				"defrost: inspect: skipping non-numeric scorer %q on %s (value=%v)\n",
+				name, caseName, score.Value)
+			continue
+		}
+		hasNumeric = true
+		if v < passThreshold {
+			pass = false
+		}
+		metrics = append(metrics, buildMetric(name, score, caseName, task, model, v, now))
+	}
+	if !hasNumeric && len(scorerNames) == 0 {
+		fmt.Fprintf(os.Stderr,
+			"defrost: inspect: sample %s has no scorers; recording as passed\n",
+			caseName)
+	}
+
+	tr := models.TestResult{
+		Id:     caseName,
+		Ran:    true,
+		Passed: pass,
+		Output: s.Output.Completion,
+	}
+	return tr, metrics
+}
+
+func buildMetric(name string, s inspectScore, caseName, task, model string, score float64, now uint64) *metricspb.Metric {
+	attrs := []*commonpb.KeyValue{
+		models.StringAttr("gen_ai.evaluation.name", name),
+		models.DoubleAttr("gen_ai.evaluation.score.value", score),
+		models.StringAttr("gen_ai.evaluation.score.label", passFailLabel(score >= passThreshold)),
+		models.StringAttr("gen_ai.evaluation.explanation", s.Explanation),
+		models.StringAttr("test.case.name", caseName),
+	}
+	if task != "" {
+		attrs = append(attrs, models.StringAttr("test.suite.name", task))
+	}
+	if model != "" {
+		attrs = append(attrs, models.StringAttr("gen_ai.request.model", model))
+	}
+	return &metricspb.Metric{
+		Name: "eval." + name,
+		Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{
+			DataPoints: []*metricspb.NumberDataPoint{{
+				TimeUnixNano: now,
+				Value:        &metricspb.NumberDataPoint_AsDouble{AsDouble: score},
+				Attributes:   attrs,
+			}},
+		}},
+	}
+}
+
+// numericScore extracts a float64 from Inspect AI's loosely-typed
+// `scores[k].value`. Standard JSON decoding into `any` gives float64 for
+// numbers; integers and floats both arrive as float64. Strings ("C", "I"),
+// objects, arrays, and nulls return false so the caller can skip them.
+func numericScore(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case json.Number:
+		f, err := x.Float64()
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	}
+	return 0, false
+}
+
+// sampleCaseName builds a deterministic case identifier of the form
+// `task="<task>",sample="<id>"`. Both fields are JSON-encoded so values
+// containing commas or quotes round-trip stably and the format matches the
+// Promptfoo adapter's key="value" convention. Task is included so multi-task
+// invocations don't collide on bare sample IDs.
+func sampleCaseName(id any, task string) string {
+	parts := make([]string, 0, 2)
+	if task != "" {
+		b, err := json.Marshal(task)
+		if err != nil {
+			parts = append(parts, fmt.Sprintf("task=%s", task))
+		} else {
+			parts = append(parts, fmt.Sprintf("task=%s", b))
+		}
+	}
+	parts = append(parts, fmt.Sprintf("sample=%s", encodeSampleID(id)))
+	return strings.Join(parts, ",")
+}
+
+// encodeSampleID renders Inspect's loosely-typed sample id as a stable
+// JSON-encoded string suitable for use in a case-name field. Integer ids
+// arrive from json.Unmarshal-into-any as float64; we render them without
+// decimal noise. Strings round-trip as JSON literals so embedded commas and
+// quotes don't break the case-name format.
+func encodeSampleID(id any) string {
+	switch v := id.(type) {
+	case nil:
+		return `"<no-id>"`
+	case string:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%q", v)
+		}
+		return string(b)
+	case float64:
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("\"%d\"", int64(v))
+		}
+		return fmt.Sprintf("%q", strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", v), "0"), "."))
+	}
+	b, err := json.Marshal(id)
+	if err != nil {
+		return fmt.Sprintf("%q", fmt.Sprintf("%v", id))
+	}
+	return string(b)
+}
+
+func passFailLabel(pass bool) string {
+	if pass {
+		return "pass"
+	}
+	return "fail"
+}

--- a/internal/eval/inspect/parser_test.go
+++ b/internal/eval/inspect/parser_test.go
@@ -1,0 +1,281 @@
+package inspect
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return raw
+}
+
+func gaugeValue(t *testing.T, m *metricspb.Metric) float64 {
+	t.Helper()
+	g, ok := m.Data.(*metricspb.Metric_Gauge)
+	if !ok {
+		t.Fatalf("expected gauge, got %T", m.Data)
+	}
+	if len(g.Gauge.DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(g.Gauge.DataPoints))
+	}
+	dp := g.Gauge.DataPoints[0]
+	dv, ok := dp.Value.(*metricspb.NumberDataPoint_AsDouble)
+	if !ok {
+		t.Fatalf("expected AsDouble, got %T", dp.Value)
+	}
+	return dv.AsDouble
+}
+
+func attrString(m *metricspb.Metric, key string) string {
+	g, _ := m.Data.(*metricspb.Metric_Gauge)
+	if g == nil || len(g.Gauge.DataPoints) == 0 {
+		return ""
+	}
+	for _, kv := range g.Gauge.DataPoints[0].Attributes {
+		if kv.Key == key {
+			if sv, ok := kv.Value.Value.(*commonpb.AnyValue_StringValue); ok {
+				return sv.StringValue
+			}
+		}
+	}
+	return ""
+}
+
+func TestParseSmoke(t *testing.T) {
+	tests, metrics, err := ParseFile(bytes.NewReader(loadFixture(t, "smoke.json")))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tests) != 2 {
+		t.Fatalf("expected 2 tests, got %d", len(tests))
+	}
+	if !tests[0].Passed {
+		t.Fatalf("expected sample 1 passed=true")
+	}
+	if tests[1].Passed {
+		t.Fatalf("expected sample 2 passed=false")
+	}
+	wantID := `task="capital_cities",sample="1"`
+	if tests[0].Id != wantID {
+		t.Fatalf("expected id=%q, got %q", wantID, tests[0].Id)
+	}
+	if tests[0].Output != "Paris" {
+		t.Fatalf("expected output=Paris, got %q", tests[0].Output)
+	}
+	if !tests[0].Ran || !tests[1].Ran {
+		t.Fatalf("expected Ran=true for both samples")
+	}
+	if len(metrics) != 2 {
+		t.Fatalf("expected 2 metrics, got %d", len(metrics))
+	}
+	if metrics[0].Name != "eval.match" {
+		t.Fatalf("expected metric eval.match, got %q", metrics[0].Name)
+	}
+	if got := gaugeValue(t, metrics[0]); got != 1.0 {
+		t.Fatalf("expected score 1.0, got %v", got)
+	}
+	if got := gaugeValue(t, metrics[1]); got != 0.0 {
+		t.Fatalf("expected score 0.0, got %v", got)
+	}
+	if got := attrString(metrics[0], "gen_ai.evaluation.name"); got != "match" {
+		t.Fatalf("expected gen_ai.evaluation.name=match, got %q", got)
+	}
+	if got := attrString(metrics[0], "gen_ai.evaluation.score.label"); got != "pass" {
+		t.Fatalf("expected score.label=pass, got %q", got)
+	}
+	if got := attrString(metrics[1], "gen_ai.evaluation.score.label"); got != "fail" {
+		t.Fatalf("expected score.label=fail, got %q", got)
+	}
+	if got := attrString(metrics[0], "test.case.name"); got != wantID {
+		t.Fatalf("expected test.case.name=%q, got %q", wantID, got)
+	}
+	if got := attrString(metrics[0], "test.suite.name"); got != "capital_cities" {
+		t.Fatalf("expected test.suite.name=capital_cities, got %q", got)
+	}
+	if got := attrString(metrics[0], "gen_ai.request.model"); got != "openai/gpt-4o" {
+		t.Fatalf("expected gen_ai.request.model=openai/gpt-4o, got %q", got)
+	}
+	if got := attrString(metrics[0], "gen_ai.evaluation.explanation"); got != "Exact match" {
+		t.Fatalf("expected explanation=Exact match, got %q", got)
+	}
+}
+
+func TestParseMultiScorer(t *testing.T) {
+	tests, metrics, err := ParseFile(bytes.NewReader(loadFixture(t, "multi_scorer.json")))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tests) != 1 {
+		t.Fatalf("expected 1 test, got %d", len(tests))
+	}
+	if !tests[0].Passed {
+		t.Fatalf("expected passed=true (both scorers ≥ 0.5)")
+	}
+	if len(metrics) != 2 {
+		t.Fatalf("expected 2 metrics (one per scorer), got %d", len(metrics))
+	}
+	wantNames := map[string]bool{"eval.accuracy": false, "eval.f1_score": false}
+	for _, m := range metrics {
+		wantNames[m.Name] = true
+	}
+	for k, v := range wantNames {
+		if !v {
+			t.Fatalf("missing expected metric %s", k)
+		}
+	}
+}
+
+func TestParseLetterScorerSkipped(t *testing.T) {
+	tests, metrics, err := ParseFile(bytes.NewReader(loadFixture(t, "letter_scorer.json")))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tests) != 2 {
+		t.Fatalf("expected 2 tests, got %d", len(tests))
+	}
+	// Both samples have only Letter scorers, which the parser skips. The
+	// fallback for "no numeric scorers" is Passed=true (no failure signal).
+	if !tests[0].Passed || !tests[1].Passed {
+		t.Fatalf("expected both samples passed=true (no numeric scorers means no failure)")
+	}
+	if len(metrics) != 0 {
+		t.Fatalf("expected 0 metrics (Letter scorers skipped), got %d", len(metrics))
+	}
+}
+
+func TestParseNoScores(t *testing.T) {
+	tests, metrics, err := ParseFile(bytes.NewReader(loadFixture(t, "no_scores.json")))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tests) != 1 {
+		t.Fatalf("expected 1 test, got %d", len(tests))
+	}
+	if !tests[0].Passed {
+		t.Fatalf("expected passed=true (no scorers means no failure)")
+	}
+	if len(metrics) != 0 {
+		t.Fatalf("expected 0 metrics, got %d", len(metrics))
+	}
+}
+
+func TestParseStringID(t *testing.T) {
+	tests, _, err := ParseFile(bytes.NewReader(loadFixture(t, "string_id.json")))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tests) != 1 {
+		t.Fatalf("expected 1 test, got %d", len(tests))
+	}
+	want := `task="string_id_eval",sample="case-paris"`
+	if tests[0].Id != want {
+		t.Fatalf("expected id=%q, got %q", want, tests[0].Id)
+	}
+}
+
+func TestParseCompoundValueSkipped(t *testing.T) {
+	tests, metrics, err := ParseFile(bytes.NewReader(loadFixture(t, "compound_value.json")))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tests) != 1 {
+		t.Fatalf("expected 1 test, got %d", len(tests))
+	}
+	if !tests[0].Passed {
+		t.Fatalf("expected passed=true (accuracy=0.95 ≥ 0.5)")
+	}
+	// Compound `multidim` is skipped; only `accuracy` produces a metric.
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric (compound skipped), got %d", len(metrics))
+	}
+	if metrics[0].Name != "eval.accuracy" {
+		t.Fatalf("expected eval.accuracy, got %q", metrics[0].Name)
+	}
+}
+
+func TestParseEmptySamples(t *testing.T) {
+	tests, metrics, err := ParseFile(bytes.NewReader(loadFixture(t, "empty_samples.json")))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tests) != 0 || len(metrics) != 0 {
+		t.Fatalf("expected zero results, got %d tests / %d metrics", len(tests), len(metrics))
+	}
+}
+
+func TestParseIntegerScore(t *testing.T) {
+	tests, metrics, err := ParseFile(bytes.NewReader(loadFixture(t, "integer_score.json")))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tests) != 1 || !tests[0].Passed {
+		t.Fatalf("expected 1 passing test, got %v", tests)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(metrics))
+	}
+	if got := gaugeValue(t, metrics[0]); got != 1.0 {
+		t.Fatalf("expected score 1.0 from integer 1, got %v", got)
+	}
+}
+
+func TestParseDeterministicCaseNames(t *testing.T) {
+	raw := loadFixture(t, "smoke.json")
+	tests1, _, err := ParseFile(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	tests2, _, err := ParseFile(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tests1) != len(tests2) {
+		t.Fatalf("non-deterministic length: %d vs %d", len(tests1), len(tests2))
+	}
+	for i := range tests1 {
+		if tests1[i].Id != tests2[i].Id {
+			t.Fatalf("non-deterministic id: %q vs %q", tests1[i].Id, tests2[i].Id)
+		}
+	}
+}
+
+func TestParseInvalidJSON(t *testing.T) {
+	_, _, err := ParseFile(bytes.NewReader([]byte("not json")))
+	if err == nil {
+		t.Fatalf("expected decode error")
+	}
+}
+
+func TestNumericScore(t *testing.T) {
+	cases := []struct {
+		in     any
+		want   float64
+		wantOK bool
+	}{
+		{1.0, 1.0, true},
+		{0.85, 0.85, true},
+		{float64(0), 0.0, true},
+		{"C", 0, false},
+		{"I", 0, false},
+		{"1.0", 0, false},
+		{nil, 0, false},
+		{map[string]any{"precision": 0.9}, 0, false},
+		{[]any{1.0}, 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := numericScore(tc.in)
+		if ok != tc.wantOK || (ok && got != tc.want) {
+			t.Errorf("numericScore(%v) = (%v, %v), want (%v, %v)", tc.in, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}

--- a/internal/eval/inspect/testdata/compound_value.json
+++ b/internal/eval/inspect/testdata/compound_value.json
@@ -1,0 +1,24 @@
+{
+  "eval": {
+    "task": "compound_eval",
+    "model": "openai/gpt-4o"
+  },
+  "samples": [
+    {
+      "id": 1,
+      "output": { "completion": "Paris" },
+      "scores": {
+        "multidim": {
+          "value": { "precision": 0.9, "recall": 0.8 },
+          "answer": "Paris",
+          "explanation": "Multi-dimensional"
+        },
+        "accuracy": {
+          "value": 0.95,
+          "answer": "Paris",
+          "explanation": "Accurate"
+        }
+      }
+    }
+  ]
+}

--- a/internal/eval/inspect/testdata/empty_samples.json
+++ b/internal/eval/inspect/testdata/empty_samples.json
@@ -1,0 +1,7 @@
+{
+  "eval": {
+    "task": "empty",
+    "model": "openai/gpt-4o"
+  },
+  "samples": []
+}

--- a/internal/eval/inspect/testdata/integer_score.json
+++ b/internal/eval/inspect/testdata/integer_score.json
@@ -1,0 +1,19 @@
+{
+  "eval": {
+    "task": "integer_eval",
+    "model": "openai/gpt-4o"
+  },
+  "samples": [
+    {
+      "id": 1,
+      "output": { "completion": "Paris" },
+      "scores": {
+        "binary_match": {
+          "value": 1,
+          "answer": "Paris",
+          "explanation": "Correct"
+        }
+      }
+    }
+  ]
+}

--- a/internal/eval/inspect/testdata/letter_scorer.json
+++ b/internal/eval/inspect/testdata/letter_scorer.json
@@ -1,0 +1,30 @@
+{
+  "eval": {
+    "task": "letter_eval",
+    "model": "openai/gpt-4o"
+  },
+  "samples": [
+    {
+      "id": 1,
+      "output": { "completion": "Paris" },
+      "scores": {
+        "exact_match": {
+          "value": "C",
+          "answer": "Paris",
+          "explanation": "Correct"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "output": { "completion": "Rome" },
+      "scores": {
+        "exact_match": {
+          "value": "I",
+          "answer": "Rome",
+          "explanation": "Incorrect"
+        }
+      }
+    }
+  ]
+}

--- a/internal/eval/inspect/testdata/multi_scorer.json
+++ b/internal/eval/inspect/testdata/multi_scorer.json
@@ -1,0 +1,24 @@
+{
+  "eval": {
+    "task": "qa_eval",
+    "model": "anthropic/claude-3-5-sonnet"
+  },
+  "samples": [
+    {
+      "id": 1,
+      "output": { "completion": "The capital is Paris." },
+      "scores": {
+        "accuracy": {
+          "value": 1.0,
+          "answer": "Paris",
+          "explanation": "Correct"
+        },
+        "f1_score": {
+          "value": 0.85,
+          "answer": "Paris",
+          "explanation": "Token overlap"
+        }
+      }
+    }
+  ]
+}

--- a/internal/eval/inspect/testdata/no_scores.json
+++ b/internal/eval/inspect/testdata/no_scores.json
@@ -1,0 +1,13 @@
+{
+  "eval": {
+    "task": "empty_eval",
+    "model": "openai/gpt-4o"
+  },
+  "samples": [
+    {
+      "id": 1,
+      "output": { "completion": "anything" },
+      "scores": {}
+    }
+  ]
+}

--- a/internal/eval/inspect/testdata/smoke.json
+++ b/internal/eval/inspect/testdata/smoke.json
@@ -1,0 +1,35 @@
+{
+  "eval": {
+    "task": "capital_cities",
+    "model": "openai/gpt-4o",
+    "dataset": { "name": "capitals" }
+  },
+  "samples": [
+    {
+      "id": 1,
+      "input": "Capital of France?",
+      "target": "Paris",
+      "output": { "completion": "Paris" },
+      "scores": {
+        "match": {
+          "value": 1.0,
+          "answer": "Paris",
+          "explanation": "Exact match"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "input": "Capital of Germany?",
+      "target": "Berlin",
+      "output": { "completion": "London" },
+      "scores": {
+        "match": {
+          "value": 0.0,
+          "answer": "London",
+          "explanation": "Mismatch"
+        }
+      }
+    }
+  ]
+}

--- a/internal/eval/inspect/testdata/string_id.json
+++ b/internal/eval/inspect/testdata/string_id.json
@@ -1,0 +1,19 @@
+{
+  "eval": {
+    "task": "string_id_eval",
+    "model": "openai/gpt-4o"
+  },
+  "samples": [
+    {
+      "id": "case-paris",
+      "output": { "completion": "Paris" },
+      "scores": {
+        "match": {
+          "value": 1.0,
+          "answer": "Paris",
+          "explanation": "Match"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements the Inspect AI adapter described in `docs/specs/2026-04-30-inspect-ai-adapter.md`:

- New `internal/eval/inspect/` package: `Adapter` (Role A) + pure `ParseFile` parser.
- Matches `inspect eval`, `python -m inspect_ai eval`, and `{poetry,uv,pipenv} run inspect eval`.
- Auto-injects `--log-dir <tempdir>` and `--log-format=json`; passthrough when the user supplied either flag.
- Emits one `eval.<scorer>` gauge per (sample, numeric scorer) with OTel Gen-AI semconv attrs (`gen_ai.evaluation.name/score.value/score.label/explanation`, `test.case.name`, `test.suite.name`, `gen_ai.request.model`).
- Skips non-numeric scorers (Letter `"C"`/`"I"`, compound objects) with a stderr warning, per v1 spec.
- Sample pass/fail heuristic: all numeric scorers ≥ 0.5 (sample with no numeric scorers passes).
- Registered in the adapter registry before pytest (stricter matcher first).

## Dogfood

`examples/inspect/task.py` ships a 4-sample task scored by a custom numeric scorer (Inspect's built-in `match()` returns Letter values which the v1 adapter skips). Two intentional failures are suppressed in the new `inspect:` CI job. Asserts the result breakdown is `2 pass, 2 fail, 0 skip` since `inspect eval` exits 0 even when samples fail scoring.

## Test plan

- [x] `go test ./internal/eval/inspect/...` — parser and adapter tests
- [x] `go vet ./...`
- [x] `go build` and run `defrost exec inspect eval task.py --model none` locally → 2 pass / 2 fail
- [x] `defrost exec inspect eval task.py --model none --log-dir /tmp/x` → passthrough warning, no results recorded
- [ ] CI: `inspect:` job passes the new result-count assertion
- [ ] CI: existing jobs (go, python, javascript, typescript, promptfoo) still pass

Closes #19

https://claude.ai/code/session_01M5uLXHntrET9agzUsQRze7

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5uLXHntrET9agzUsQRze7)_