### PR TITLE
persist: switch data branch to OTLP/protobuf + zstd, atomic per-run files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Every team wants a record of how their evals, benchmarks, and tests have changed
 over time. Almost nobody wants to host a database for it. **defrost** records
-each run as commits on a `_defrost-v2` branch in the same repo, so the history
+each run as commits on a `_defrost` branch in the same repo, so the history
 travels with the code — no database, no SaaS, no API keys.
 
 ## What you get
@@ -78,7 +78,7 @@ and records everything. Exit code:
 
 - Normally the child's exit code.
 - If every failing test is on the suppression list, the exit is rewritten to `0`.
-- If persisting to the `_defrost-v2` branch fails (e.g. push rejected,
+- If persisting to the `_defrost` branch fails (e.g. push rejected,
   no `origin`), the exit is forced to `1` even when the test command itself
   succeeded — so CI never silently loses data.
 
@@ -98,7 +98,7 @@ Serves the dashboard at `127.0.0.1:6969` (override with `--port`).
 
 ## Storage
 
-Every run is committed to a `_defrost-v2` branch (configurable with
+Every run is committed to a `_defrost` branch (configurable with
 `--data-branch`) in your repo. Clone the repo to get the history. Push the
 repo to share it. Concurrent runs from different machines never conflict
 because each writer owns a unique filename (one file per run, named by its
@@ -117,7 +117,7 @@ and metrics emitted during the run are persisted as OTel metric data
 points. Each file is the canonical OTLP/Protobuf payload, zstd-compressed.
 
 ```
-_defrost-v2 branch
+_defrost branch
 ├── traces/<YYYY>/<MM>/<DD>/<trace_id>.otlp.pb.zst    # one ExportTraceServiceRequest per run
 ├── metrics/<YYYY>/<MM>/<DD>/<trace_id>.otlp.pb.zst   # one ExportMetricsServiceRequest per run
 └── suppressions.json
@@ -128,7 +128,3 @@ Run-scoped attributes (commit, branch, author, command, OS/arch, run id,
 the canonical fully qualified test name — no lossy projections are stored
 alongside it. Compaction (collapsing many per-run files into one daily
 file) is on the roadmap.
-
-> **Migration note**: this is a hard cut from the original line-oriented
-> `_defrost` layout. Old `_defrost` branches are not migrated; users
-> repopulate by running CI under the new version.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Every team wants a record of how their evals, benchmarks, and tests have changed
 over time. Almost nobody wants to host a database for it. **defrost** records
-each run as commits on a `_defrost` branch in the same repo, so the history
+each run as commits on a `_defrost-v2` branch in the same repo, so the history
 travels with the code — no database, no SaaS, no API keys.
 
 ## What you get
@@ -78,7 +78,7 @@ and records everything. Exit code:
 
 - Normally the child's exit code.
 - If every failing test is on the suppression list, the exit is rewritten to `0`.
-- If persisting to the `_defrost` branch fails (e.g. push rejected,
+- If persisting to the `_defrost-v2` branch fails (e.g. push rejected,
   no `origin`), the exit is forced to `1` even when the test command itself
   succeeded — so CI never silently loses data.
 
@@ -98,9 +98,11 @@ Serves the dashboard at `127.0.0.1:6969` (override with `--port`).
 
 ## Storage
 
-Every run is committed to a `_defrost` branch (configurable with
+Every run is committed to a `_defrost-v2` branch (configurable with
 `--data-branch`) in your repo. Clone the repo to get the history. Push the
-repo to share it. Concurrent runs from different machines append cleanly.
+repo to share it. Concurrent runs from different machines never conflict
+because each writer owns a unique filename (one file per run, named by its
+OTel `trace_id`).
 
 To experiment without touching git, pass `--no-persist` (don't store
 anything) or `--dev` (write to `.defrost-dev/` instead of the data branch).
@@ -110,15 +112,23 @@ anything) or `--dev` (write to `.defrost-dev/` instead of the data branch).
 For the curious — you do not need to know any of this to use defrost.
 
 The data branch is shaped like OpenTelemetry. One `defrost exec` invocation
-is one trace; the run is the root span; each test is a child span. Evals and
-metrics emitted during the run are persisted as OTel metric data points.
+is one trace; the run is the root span; each test is a child span. Evals
+and metrics emitted during the run are persisted as OTel metric data
+points. Each file is the canonical OTLP/Protobuf payload, zstd-compressed.
 
 ```
-_defrost branch
-├── traces/<span_name>.ndjson     # one OTel span per line (run + per-test)
-├── metrics/<metric_name>.ndjson  # one OTel metric data point per line
+_defrost-v2 branch
+├── traces/<YYYY>/<MM>/<DD>/<trace_id>.otlp.pb.zst    # one ExportTraceServiceRequest per run
+├── metrics/<YYYY>/<MM>/<DD>/<trace_id>.otlp.pb.zst   # one ExportMetricsServiceRequest per run
 └── suppressions.json
 ```
 
-`traces/` and `metrics/` files use Git's `merge=union` attribute so
-concurrent writers append without conflicts.
+Run-scoped attributes (commit, branch, author, command, OS/arch, run id,
+…) live exactly once on each file's `Resource`. The OTel span `name` is
+the canonical fully qualified test name — no lossy projections are stored
+alongside it. Compaction (collapsing many per-run files into one daily
+file) is on the roadmap.
+
+> **Migration note**: this is a hard cut from the original line-oriented
+> `_defrost` layout. Old `_defrost` branches are not migrated; users
+> repopulate by running CI under the new version.

--- a/cli.go
+++ b/cli.go
@@ -4,7 +4,7 @@ var CLI struct {
 	Exec struct {
 		Cmd        []string `arg:"" name:"cmd" passthrough:"" help:"Test command to run."`
 		RepoDir    string   `name:"repo-dir" default:"." help:"Path to the git repo to persist into."`
-		DataBranch string   `name:"data-branch" default:"_defrost" help:"Branch name where results are stored."`
+		DataBranch string   `name:"data-branch" default:"_defrost-v2" help:"Branch name where results are stored."`
 		NoPersist  bool     `name:"no-persist" help:"Run tests without persisting results."`
 		NoRemote   bool     `name:"no-remote" help:"Persist locally only — store the data branch in the local repo and do not push."`
 		Dev        bool     `name:"dev" short:"d" help:"Dev mode: write results to <repo-dir>/.defrost-dev (gitignored scratch dir) instead of committing/pushing. For developing defrost itself."`
@@ -13,7 +13,7 @@ var CLI struct {
 	History struct {
 		Test       string `arg:"" name:"test" help:"Full test name (package + test, e.g. github.com/x/p/TestA)."`
 		RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
-		DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name to read from."`
+		DataBranch string `name:"data-branch" default:"_defrost-v2" help:"Branch name to read from."`
 		NoRemote   bool   `name:"no-remote" help:"Read from the local repo only — do not consult origin."`
 	} `cmd:"" help:"Print recorded history for a single test as NDJSON."`
 
@@ -21,7 +21,7 @@ var CLI struct {
 		Add struct {
 			Tests      []string `arg:"" name:"tests" help:"One or more test IDs to suppress (same form as 'defrost history'). All IDs land in a single commit on the data branch."`
 			RepoDir    string   `name:"repo-dir" default:"." help:"Path to the git repo."`
-			DataBranch string   `name:"data-branch" default:"_defrost" help:"Branch name where suppressions are stored."`
+			DataBranch string   `name:"data-branch" default:"_defrost-v2" help:"Branch name where suppressions are stored."`
 			NoRemote   bool     `name:"no-remote" help:"Write to the local repo only — do not push."`
 			Dev        bool     `name:"dev" short:"d" help:"Dev mode: read/write the local scratch dir instead of the data branch."`
 		} `cmd:"" help:"Add one or more test IDs to the suppression list."`
@@ -29,14 +29,14 @@ var CLI struct {
 		Remove struct {
 			Test       string `arg:"" name:"test" help:"Full test ID to remove from the suppression list."`
 			RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
-			DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name where suppressions are stored."`
+			DataBranch string `name:"data-branch" default:"_defrost-v2" help:"Branch name where suppressions are stored."`
 			NoRemote   bool   `name:"no-remote" help:"Write to the local repo only — do not push."`
 			Dev        bool   `name:"dev" short:"d" help:"Dev mode: read/write the local scratch dir instead of the data branch."`
 		} `cmd:"" help:"Remove a test from the suppression list."`
 
 		List struct {
 			RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
-			DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name to read from."`
+			DataBranch string `name:"data-branch" default:"_defrost-v2" help:"Branch name to read from."`
 			NoRemote   bool   `name:"no-remote" help:"Read from the local repo only — do not consult origin."`
 			Dev        bool   `name:"dev" short:"d" help:"Dev mode: read the local scratch dir instead of the data branch."`
 		} `cmd:"" help:"List the suppressed test IDs, one per line."`
@@ -45,7 +45,7 @@ var CLI struct {
 	Serve struct {
 		Port       int    `name:"port" default:"6969" help:"Port to bind on 127.0.0.1."`
 		RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
-		DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name to read from."`
+		DataBranch string `name:"data-branch" default:"_defrost-v2" help:"Branch name to read from."`
 		NoRemote   bool   `name:"no-remote" help:"Read from the local repo only — do not consult origin."`
 	} `cmd:"" help:"Serve a local UI for inspecting test history."`
 }

--- a/cli.go
+++ b/cli.go
@@ -4,7 +4,7 @@ var CLI struct {
 	Exec struct {
 		Cmd        []string `arg:"" name:"cmd" passthrough:"" help:"Test command to run."`
 		RepoDir    string   `name:"repo-dir" default:"." help:"Path to the git repo to persist into."`
-		DataBranch string   `name:"data-branch" default:"_defrost-v2" help:"Branch name where results are stored."`
+		DataBranch string   `name:"data-branch" default:"_defrost" help:"Branch name where results are stored."`
 		NoPersist  bool     `name:"no-persist" help:"Run tests without persisting results."`
 		NoRemote   bool     `name:"no-remote" help:"Persist locally only — store the data branch in the local repo and do not push."`
 		Dev        bool     `name:"dev" short:"d" help:"Dev mode: write results to <repo-dir>/.defrost-dev (gitignored scratch dir) instead of committing/pushing. For developing defrost itself."`
@@ -13,7 +13,7 @@ var CLI struct {
 	History struct {
 		Test       string `arg:"" name:"test" help:"Full test name (package + test, e.g. github.com/x/p/TestA)."`
 		RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
-		DataBranch string `name:"data-branch" default:"_defrost-v2" help:"Branch name to read from."`
+		DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name to read from."`
 		NoRemote   bool   `name:"no-remote" help:"Read from the local repo only — do not consult origin."`
 	} `cmd:"" help:"Print recorded history for a single test as NDJSON."`
 
@@ -21,7 +21,7 @@ var CLI struct {
 		Add struct {
 			Tests      []string `arg:"" name:"tests" help:"One or more test IDs to suppress (same form as 'defrost history'). All IDs land in a single commit on the data branch."`
 			RepoDir    string   `name:"repo-dir" default:"." help:"Path to the git repo."`
-			DataBranch string   `name:"data-branch" default:"_defrost-v2" help:"Branch name where suppressions are stored."`
+			DataBranch string   `name:"data-branch" default:"_defrost" help:"Branch name where suppressions are stored."`
 			NoRemote   bool     `name:"no-remote" help:"Write to the local repo only — do not push."`
 			Dev        bool     `name:"dev" short:"d" help:"Dev mode: read/write the local scratch dir instead of the data branch."`
 		} `cmd:"" help:"Add one or more test IDs to the suppression list."`
@@ -29,14 +29,14 @@ var CLI struct {
 		Remove struct {
 			Test       string `arg:"" name:"test" help:"Full test ID to remove from the suppression list."`
 			RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
-			DataBranch string `name:"data-branch" default:"_defrost-v2" help:"Branch name where suppressions are stored."`
+			DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name where suppressions are stored."`
 			NoRemote   bool   `name:"no-remote" help:"Write to the local repo only — do not push."`
 			Dev        bool   `name:"dev" short:"d" help:"Dev mode: read/write the local scratch dir instead of the data branch."`
 		} `cmd:"" help:"Remove a test from the suppression list."`
 
 		List struct {
 			RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
-			DataBranch string `name:"data-branch" default:"_defrost-v2" help:"Branch name to read from."`
+			DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name to read from."`
 			NoRemote   bool   `name:"no-remote" help:"Read from the local repo only — do not consult origin."`
 			Dev        bool   `name:"dev" short:"d" help:"Dev mode: read the local scratch dir instead of the data branch."`
 		} `cmd:"" help:"List the suppressed test IDs, one per line."`
@@ -45,7 +45,7 @@ var CLI struct {
 	Serve struct {
 		Port       int    `name:"port" default:"6969" help:"Port to bind on 127.0.0.1."`
 		RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
-		DataBranch string `name:"data-branch" default:"_defrost-v2" help:"Branch name to read from."`
+		DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name to read from."`
 		NoRemote   bool   `name:"no-remote" help:"Read from the local repo only — do not consult origin."`
 	} `cmd:"" help:"Serve a local UI for inspecting test history."`
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -287,12 +287,23 @@ func TestExecPlumbsAdapterMetricsToPersistence(t *testing.T) {
 		t.Fatalf("expected exit 0, got %d", code)
 	}
 
-	// The persist package has no GetMetricHistory API; assert the round-trip
-	// by verifying the metric was written to the dev scratch directory.
-	// fileBackend writes one NDJSON file per metric name under metrics/.
-	metricFile := filepath.Join(repo, persist.DevDir, "metrics",
-		persist.EncodeName("eval.faithfulness")+".ndjson")
-	if _, err := os.Stat(metricFile); err != nil {
-		t.Fatalf("expected persisted metric file %s, got: %v", metricFile, err)
+	// Assert the round-trip by querying the in-memory backend.
+	loaded, err := persist.New(persist.Options{RepoDir: repo, Dev: true}).LoadAllMetrics()
+	if err != nil {
+		t.Fatalf("LoadAllMetrics: %v", err)
+	}
+	var foundFaithfulness bool
+	for _, rm := range loaded {
+		m := persist.MetricFromResourceMetrics(rm)
+		if m == nil {
+			continue
+		}
+		if m.Name == "eval.faithfulness" {
+			foundFaithfulness = true
+			break
+		}
+	}
+	if !foundFaithfulness {
+		t.Errorf("expected eval.faithfulness in loaded metrics, got %d records", len(loaded))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
+	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/internal/otlp/translate.go
+++ b/internal/otlp/translate.go
@@ -34,21 +34,6 @@ func testResultToSpan(r models.TestResult, run models.RunContext) *tracepb.Span 
 	endNs := startNs + uint64(r.Duration.Nanoseconds())
 
 	resultStatus := mapResultStatus(r)
-	attrs := []*commonpb.KeyValue{
-		models.StringAttr("test.case.name", r.Id),
-		models.StringAttr("test.case.result.status", resultStatus),
-		models.StringAttr("defrost.run_id", run.RunID),
-	}
-	if suite := suiteFromTestID(r.Id); suite != "" {
-		attrs = append(attrs, models.StringAttr("test.suite.name", suite))
-	}
-	ns, fn := codeFromTestID(r.Id)
-	if ns != "" {
-		attrs = append(attrs, models.StringAttr("code.namespace", ns))
-	}
-	if fn != "" {
-		attrs = append(attrs, models.StringAttr("code.function", fn))
-	}
 
 	var events []*tracepb.Span_Event
 	if r.Output != "" {
@@ -68,7 +53,7 @@ func testResultToSpan(r models.TestResult, run models.RunContext) *tracepb.Span 
 		StartTimeUnixNano: startNs,
 		EndTimeUnixNano:   endNs,
 		Status:            resultToSpanStatus(resultStatus, r.Output),
-		Attributes:        attrs,
+		Attributes:        []*commonpb.KeyValue{models.StringAttr("test.case.result.status", resultStatus)},
 		Events:            events,
 	}
 }
@@ -98,33 +83,6 @@ func resultToSpanStatus(resultStatus, output string) *tracepb.Status {
 		return &tracepb.Status{Code: tracepb.Status_STATUS_CODE_ERROR, Message: firstLine(output)}
 	}
 	return &tracepb.Status{Code: tracepb.Status_STATUS_CODE_UNSET}
-}
-
-// suiteFromTestID extracts the suite identifier:
-// "github.com/x/p/TestFoo" → "github.com/x/p"
-// "tests/test_foo.py::TestClass::test_method" → "tests/test_foo.py"
-func suiteFromTestID(id string) string {
-	if suite, _, ok := strings.Cut(id, "::"); ok {
-		return suite
-	}
-	if i := strings.LastIndex(id, "/"); i >= 0 {
-		return id[:i]
-	}
-	return ""
-}
-
-// codeFromTestID returns (namespace, function) for a test id. For Go
-// "<pkg>/TestFoo" the namespace is the package and function is the test
-// name. For pytest "<file>::<class>::<method>" the namespace is the file
-// path and function is the trailing token.
-func codeFromTestID(id string) (string, string) {
-	if i := strings.LastIndex(id, "::"); i >= 0 {
-		return suiteFromTestID(id), id[i+2:]
-	}
-	if i := strings.LastIndex(id, "/"); i >= 0 {
-		return id[:i], id[i+1:]
-	}
-	return "", id
 }
 
 func firstLine(s string) string {

--- a/internal/otlp/translate_test.go
+++ b/internal/otlp/translate_test.go
@@ -57,20 +57,22 @@ func TestTestResultsToSpans_Pass(t *testing.T) {
 	if s.Status.Code != tracepb.Status_STATUS_CODE_OK {
 		t.Errorf("status.code: want OK got %v", s.Status.Code)
 	}
-	if got := models.AttrString(s.Attributes, "test.case.name"); got != r.Id {
-		t.Errorf("test.case.name attribute: %q", got)
-	}
 	if got := models.AttrString(s.Attributes, "test.case.result.status"); got != "passed" {
 		t.Errorf("test.case.result.status: %q", got)
 	}
-	if got := models.AttrString(s.Attributes, "defrost.run_id"); got != "run-001" {
-		t.Errorf("defrost.run_id attribute missing: %q", got)
+	// Schema 4 stores ONLY test.case.result.status on the test span — the
+	// FQN lives in span.Name and run identity lives on the Resource.
+	if got := models.AttrString(s.Attributes, "test.case.name"); got != "" {
+		t.Errorf("test.case.name should be absent, got %q", got)
 	}
-	if got := models.AttrString(s.Attributes, "test.suite.name"); got != "github.com/x/p" {
-		t.Errorf("test.suite.name: %q", got)
+	if got := models.AttrString(s.Attributes, "defrost.run_id"); got != "" {
+		t.Errorf("defrost.run_id should be absent, got %q", got)
 	}
-	if got := models.AttrString(s.Attributes, "code.function"); got != "TestA" {
-		t.Errorf("code.function: %q", got)
+	if got := models.AttrString(s.Attributes, "test.suite.name"); got != "" {
+		t.Errorf("test.suite.name should be absent, got %q", got)
+	}
+	if got := models.AttrString(s.Attributes, "code.function"); got != "" {
+		t.Errorf("code.function should be absent, got %q", got)
 	}
 	if d := s.EndTimeUnixNano - s.StartTimeUnixNano; d != uint64(5*time.Millisecond) {
 		t.Errorf("duration nanos: want %d got %d", uint64(5*time.Millisecond), d)
@@ -139,17 +141,17 @@ func TestTestResultsToSpans_Panic(t *testing.T) {
 }
 
 func TestTestResultsToSpans_PytestId(t *testing.T) {
+	// Schema 4: the FQN is the canonical identifier and lives in span.Name.
+	// Lossy projections (test.suite.name, code.function) are no longer
+	// emitted — the reader can split the FQN if it wants.
 	r := models.TestResult{
 		Id:     "tests/test_module.py::TestClass::test_method",
 		Ran:    true,
 		Passed: true,
 	}
 	s := TestResultsToSpans([]models.TestResult{r}, newRunContext())[0]
-	if got := models.AttrString(s.Attributes, "test.suite.name"); got != "tests/test_module.py" {
-		t.Errorf("test.suite.name: %q", got)
-	}
-	if got := models.AttrString(s.Attributes, "code.function"); got != "test_method" {
-		t.Errorf("code.function: %q", got)
+	if s.Name != r.Id {
+		t.Errorf("FQN preserved on span.Name: want %q got %q", r.Id, s.Name)
 	}
 }
 

--- a/internal/persist/persist.go
+++ b/internal/persist/persist.go
@@ -1,45 +1,50 @@
 package persist
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/rand"
 	"crypto/sha1"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
+	goruntime "runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/klauspost/compress/zstd"
+	cmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	ctracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
-	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/bjk95/defrost/internal/models"
 )
 
 const (
-	DefaultDataBranch = "_defrost"
+	DefaultDataBranch = "_defrost-v2"
 
 	botName  = "defrost[bot]"
 	botEmail = "defrost[bot]@users.noreply.github.com"
 
-	gitAttributes = "traces/*.ndjson merge=union\nmetrics/*.ndjson merge=union\n"
-	readme        = "# defrost data branch\n\nManaged by the defrost CLI. Do not edit by hand.\n"
+	readme = "# defrost data branch\n\nManaged by the defrost CLI. Do not edit by hand.\n"
 
 	maxPushAttempts = 5
 
 	rootSpanName = "defrost.run"
+
+	// fileSuffix is appended to every per-trace and per-run-metrics file
+	// on disk. Zstd-compressed OTLP/Protobuf.
+	fileSuffix = ".otlp.pb.zst"
 )
 
 // RootSpanName is the OTel span.Name used for every defrost.run root span.
@@ -59,26 +64,25 @@ type Options struct {
 const DevDir = ".defrost-dev"
 
 // Backend is the swappable persistence layer. Spans and metrics are
-// passed and returned as the canonical OTel proto types — *tracepb.Span,
-// *metricspb.Metric — wrapped in their per-record Resource via
-// *tracepb.ResourceSpans / *metricspb.ResourceMetrics. On disk each
-// line is one ResourceSpans (single Span) or one ResourceMetrics
-// (single Metric with one data point).
+// passed in as canonical OTel proto types and stored as zstd-compressed
+// OTLP/Protobuf payloads — one file per signal per defrost exec
+// invocation, named by the run's trace_id and partitioned by run-start
+// UTC date.
 type Backend interface {
 	InitialisePersistence() error
 
 	// InsertNewRun atomically persists everything produced by one
 	// defrost exec invocation: the root run span, every test span, and
-	// every metric data point. Each ResourceSpans / ResourceMetrics
-	// carries its own Resource — span and metric Resources may differ
-	// (caller strips run-unique fields from the metric Resource to keep
-	// metric cardinality bounded).
+	// every metric data point. Writes one trace file and (if metrics
+	// are present) one metrics file. Span and metric Resources may
+	// differ — callers strip run-unique fields from the metric Resource
+	// to keep metric cardinality bounded.
 	InsertNewRun(traces []*tracepb.ResourceSpans, metrics []*metricspb.ResourceMetrics) error
 
-	// GetTestHistory returns every span persisted under
-	// traces/<testName>.ndjson, sorted oldest first by start time. Each
-	// element is a ResourceSpans containing exactly one Span. Empty
-	// slice when nothing matches.
+	// GetTestHistory returns every span whose Name == testName across
+	// every persisted trace file, sorted oldest first by start time.
+	// Each returned element is a ResourceSpans containing exactly one
+	// Span. Empty slice when nothing matches.
 	GetTestHistory(testName string) ([]*tracepb.ResourceSpans, error)
 
 	// GetSuppressions returns the current list of suppressed test IDs,
@@ -90,16 +94,16 @@ type Backend interface {
 	UpdateSuppressions(mutate func([]string) []string, msg string) error
 
 	// LoadAll returns every root run span and every test span across
-	// all files, grouped by encoded span name. Used by `defrost serve`
-	// to populate the heatmap grid in a single read instead of N.
-	// Returns nil slices/maps when there is no data yet.
+	// all persisted trace files, grouped by encoded span name. Used by
+	// `defrost serve` to populate the heatmap grid in a single read
+	// instead of N. Returns nil slices/maps when there is no data yet.
 	LoadAll() (rootSpans []*tracepb.ResourceSpans, byEncodedName map[string][]*tracepb.ResourceSpans, err error)
 
 	// LoadAllMetrics returns every persisted metric data point across
-	// all metrics/*.ndjson files. Each element is a ResourceMetrics
-	// containing exactly one Metric with one data point — the storage
-	// shape produced by InsertNewRun. Returns nil when there is no
-	// metrics data on disk.
+	// all metrics files. Each element is a ResourceMetrics containing
+	// exactly one Metric — the same shape callers produced before the
+	// per-run bundling under WrapMetricsInResource. Returns nil when
+	// there is no metrics data on disk.
 	LoadAllMetrics() ([]*metricspb.ResourceMetrics, error)
 }
 
@@ -147,12 +151,11 @@ func DetectRunContext(opts Options, cmd []string, defrostVersion string) (models
 		models.StringAttr("service.name", "defrost"),
 		models.StringAttr("service.version", defrostVersion),
 		models.StringAttr("cicd.pipeline.run.id", runID),
-		models.StringAttr("host.os.type", runtime.GOOS),
-		models.StringAttr("host.arch", runtime.GOARCH),
-		models.StringAttr("process.runtime.version", runtime.Version()),
+		models.StringAttr("host.os.type", goruntime.GOOS),
+		models.StringAttr("host.arch", goruntime.GOARCH),
+		models.StringAttr("process.runtime.version", goruntime.Version()),
 		models.StringArrayAttr("defrost.cmd", cmd),
 		models.StringAttr("defrost.cmd_hash", cmdHash(cmd)),
-		models.StringAttr("defrost.run_id", runID),
 		models.StringAttr("defrost.runner", inferRunner(cmd)),
 	}
 
@@ -213,13 +216,12 @@ func MetricResource(run models.RunContext) *resourcepb.Resource {
 		return nil
 	}
 	skip := map[string]struct{}{
-		"defrost.run_id":             {},
-		"cicd.pipeline.run.id":       {},
-		"defrost.cmd":                {},
-		"defrost.dirty_hash":         {},
-		"defrost.author_email":       {},
-		"defrost.author_name":        {},
-		"defrost.parent_commit":      {},
+		"cicd.pipeline.run.id":        {},
+		"defrost.cmd":                 {},
+		"defrost.dirty_hash":          {},
+		"defrost.author_email":        {},
+		"defrost.author_name":         {},
+		"defrost.parent_commit":       {},
 		"vcs.repository.ref.revision": {},
 	}
 	out := &resourcepb.Resource{}
@@ -260,7 +262,6 @@ func NewRootSpan(run models.RunContext) *tracepb.Span {
 		Kind:              tracepb.Span_SPAN_KIND_INTERNAL,
 		StartTimeUnixNano: uint64(run.StartTimeUnixNano),
 		Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_UNSET},
-		Attributes:        []*commonpb.KeyValue{models.StringAttr("defrost.run_id", run.RunID)},
 	}
 }
 
@@ -297,50 +298,50 @@ func runFQN(repoDir string, cmd []string) string {
 	return strings.TrimSuffix(prefix, "/") + "¬" + joined
 }
 
-// WrapSpansInResource constructs one *tracepb.ResourceSpans per span,
-// each carrying the same Resource. This is the storage shape: each line
-// in traces/<name>.ndjson is one ResourceSpans with a single Span.
+// WrapSpansInResource bundles every span produced by one defrost exec
+// invocation (root + every test span) into a single *tracepb.ResourceSpans
+// — the on-disk shape under traces/. The caller passes the run's full
+// Resource; we stash the spans under a single ScopeSpans named "defrost"
+// so all attribute identity lives exactly once on the Resource.
+//
+// Returned slice has at most one element; nil if no spans.
 func WrapSpansInResource(resource *resourcepb.Resource, spans []*tracepb.Span) []*tracepb.ResourceSpans {
 	if len(spans) == 0 {
 		return nil
 	}
-	out := make([]*tracepb.ResourceSpans, 0, len(spans))
-	for _, s := range spans {
-		out = append(out, &tracepb.ResourceSpans{
-			Resource: resource,
-			ScopeSpans: []*tracepb.ScopeSpans{{
-				Scope: &commonpb.InstrumentationScope{Name: "defrost"},
-				Spans: []*tracepb.Span{s},
-			}},
-		})
-	}
-	return out
+	return []*tracepb.ResourceSpans{{
+		Resource: resource,
+		ScopeSpans: []*tracepb.ScopeSpans{{
+			Scope: &commonpb.InstrumentationScope{Name: "defrost"},
+			Spans: spans,
+		}},
+	}}
 }
 
-// WrapMetricsInResource constructs one *metricspb.ResourceMetrics per
-// metric, each carrying the same Resource. This is the storage shape:
-// each line in metrics/<name>.ndjson is one ResourceMetrics with a
-// single Metric (which itself contains one data point).
+// WrapMetricsInResource bundles every metric data point emitted during
+// one defrost exec invocation into a single *metricspb.ResourceMetrics.
+//
+// Returned slice has at most one element; nil if no metrics.
 func WrapMetricsInResource(resource *resourcepb.Resource, metrics []*metricspb.Metric) []*metricspb.ResourceMetrics {
 	if len(metrics) == 0 {
 		return nil
 	}
-	out := make([]*metricspb.ResourceMetrics, 0, len(metrics))
-	for _, m := range metrics {
-		out = append(out, &metricspb.ResourceMetrics{
-			Resource: resource,
-			ScopeMetrics: []*metricspb.ScopeMetrics{{
-				Scope:   &commonpb.InstrumentationScope{Name: "defrost"},
-				Metrics: []*metricspb.Metric{m},
-			}},
-		})
-	}
-	return out
+	return []*metricspb.ResourceMetrics{{
+		Resource: resource,
+		ScopeMetrics: []*metricspb.ScopeMetrics{{
+			Scope:   &commonpb.InstrumentationScope{Name: "defrost"},
+			Metrics: metrics,
+		}},
+	}}
 }
 
-// SpanFromResourceSpans returns the single *tracepb.Span inside a
-// ResourceSpans we wrote. Panics if the ResourceSpans is empty (we never
-// write empty wrappers).
+// SpanFromResourceSpans returns the first *tracepb.Span inside a
+// ResourceSpans we wrote. Returns nil if there are no spans.
+//
+// Used by the read path (history, dashboard) where spans are filtered
+// individually after a file is decoded — at decode time the per-trace
+// file has been split back into one ResourceSpans per span via
+// SplitResourceSpans.
 func SpanFromResourceSpans(rs *tracepb.ResourceSpans) *tracepb.Span {
 	if rs == nil || len(rs.ScopeSpans) == 0 || len(rs.ScopeSpans[0].Spans) == 0 {
 		return nil
@@ -348,13 +349,55 @@ func SpanFromResourceSpans(rs *tracepb.ResourceSpans) *tracepb.Span {
 	return rs.ScopeSpans[0].Spans[0]
 }
 
-// MetricFromResourceMetrics returns the single *metricspb.Metric inside
+// MetricFromResourceMetrics returns the first *metricspb.Metric inside
 // a ResourceMetrics we wrote.
 func MetricFromResourceMetrics(rm *metricspb.ResourceMetrics) *metricspb.Metric {
 	if rm == nil || len(rm.ScopeMetrics) == 0 || len(rm.ScopeMetrics[0].Metrics) == 0 {
 		return nil
 	}
 	return rm.ScopeMetrics[0].Metrics[0]
+}
+
+// SplitResourceSpans expands one *tracepb.ResourceSpans (containing N
+// spans across its ScopeSpans) into N single-span *tracepb.ResourceSpans
+// values — each carrying the original Resource. This is the inverse of
+// WrapSpansInResource at read time, so existing callers that expect
+// one Span per ResourceSpans (history, dashboard grid, run resolver)
+// keep working unchanged.
+func SplitResourceSpans(rs *tracepb.ResourceSpans) []*tracepb.ResourceSpans {
+	if rs == nil {
+		return nil
+	}
+	var out []*tracepb.ResourceSpans
+	for _, ss := range rs.ScopeSpans {
+		for _, s := range ss.Spans {
+			out = append(out, &tracepb.ResourceSpans{
+				Resource:   rs.Resource,
+				ScopeSpans: []*tracepb.ScopeSpans{{Scope: ss.Scope, Spans: []*tracepb.Span{s}}},
+			})
+		}
+	}
+	return out
+}
+
+// SplitResourceMetrics is the inverse of WrapMetricsInResource at read
+// time: it expands one *metricspb.ResourceMetrics into one
+// *metricspb.ResourceMetrics per *metricspb.Metric, each carrying the
+// original Resource. Existing callers expect one Metric per record.
+func SplitResourceMetrics(rm *metricspb.ResourceMetrics) []*metricspb.ResourceMetrics {
+	if rm == nil {
+		return nil
+	}
+	var out []*metricspb.ResourceMetrics
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out = append(out, &metricspb.ResourceMetrics{
+				Resource:     rm.Resource,
+				ScopeMetrics: []*metricspb.ScopeMetrics{{Scope: sm.Scope, Metrics: []*metricspb.Metric{m}}},
+			})
+		}
+	}
+	return out
 }
 
 // gitBackend stores spans and metrics on a dedicated git data branch.
@@ -367,10 +410,7 @@ func (b *gitBackend) InsertNewRun(traces []*tracepb.ResourceSpans, metrics []*me
 		return nil
 	}
 
-	branch := b.opts.DataBranch
-	if branch == "" {
-		branch = DefaultDataBranch
-	}
+	branch := b.dataBranch()
 
 	remoteURL, err := resolveTargetURL(b.opts)
 	if err != nil {
@@ -394,10 +434,7 @@ func (b *gitBackend) InsertNewRun(traces []*tracepb.ResourceSpans, metrics []*me
 		}
 	}
 
-	if err := appendSpans(workDir, traces); err != nil {
-		return err
-	}
-	if err := appendMetrics(workDir, metrics); err != nil {
+	if err := writeRunFiles(workDir, traces, metrics); err != nil {
 		return err
 	}
 
@@ -409,94 +446,69 @@ func (b *gitBackend) InsertNewRun(traces []*tracepb.ResourceSpans, metrics []*me
 }
 
 func (b *gitBackend) GetTestHistory(testName string) ([]*tracepb.ResourceSpans, error) {
-	branch := b.opts.DataBranch
-	if branch == "" {
-		branch = DefaultDataBranch
-	}
-	remoteURL, err := resolveTargetURL(b.opts)
-	if err != nil {
+	dir, cleanup, err := b.cloneForRead()
+	if err != nil || dir == "" {
 		return nil, err
 	}
-	exists, err := branchExistsOnRemote(remoteURL, branch)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		return nil, nil
-	}
-
-	workDir, err := os.MkdirTemp("", "defrost-read-")
-	if err != nil {
-		return nil, fmt.Errorf("mktemp: %w", err)
-	}
-	defer os.RemoveAll(workDir)
-	_ = os.Remove(workDir)
-
-	if _, err := runGit("", "clone", "--quiet", "--depth=1", "--single-branch", "--branch", branch, remoteURL, workDir); err != nil {
-		return nil, fmt.Errorf("clone data branch: %w", err)
-	}
-
-	return readSpansFromDir(workDir, testName)
+	defer cleanup()
+	return readTestHistoryFromDir(dir, testName)
 }
 
 func (b *gitBackend) LoadAll() ([]*tracepb.ResourceSpans, map[string][]*tracepb.ResourceSpans, error) {
-	branch := b.opts.DataBranch
-	if branch == "" {
-		branch = DefaultDataBranch
-	}
-	remoteURL, err := resolveTargetURL(b.opts)
-	if err != nil {
+	dir, cleanup, err := b.cloneForRead()
+	if err != nil || dir == "" {
 		return nil, nil, err
 	}
-	exists, err := branchExistsOnRemote(remoteURL, branch)
-	if err != nil {
-		return nil, nil, err
-	}
-	if !exists {
-		return nil, nil, nil
-	}
-
-	workDir, err := os.MkdirTemp("", "defrost-read-")
-	if err != nil {
-		return nil, nil, fmt.Errorf("mktemp: %w", err)
-	}
-	defer os.RemoveAll(workDir)
-	_ = os.Remove(workDir)
-
-	if _, err := runGit("", "clone", "--quiet", "--depth=1", "--single-branch", "--branch", branch, remoteURL, workDir); err != nil {
-		return nil, nil, fmt.Errorf("clone data branch: %w", err)
-	}
-	return readAllSpans(workDir)
+	defer cleanup()
+	return readAllSpans(dir)
 }
 
 func (b *gitBackend) LoadAllMetrics() ([]*metricspb.ResourceMetrics, error) {
-	branch := b.opts.DataBranch
-	if branch == "" {
-		branch = DefaultDataBranch
+	dir, cleanup, err := b.cloneForRead()
+	if err != nil || dir == "" {
+		return nil, err
 	}
+	defer cleanup()
+	return readAllMetrics(dir)
+}
+
+func (b *gitBackend) dataBranch() string {
+	if b.opts.DataBranch != "" {
+		return b.opts.DataBranch
+	}
+	return DefaultDataBranch
+}
+
+// cloneForRead clones the data branch with a strategy tuned for bulk
+// reads: full checkout (no blob filtering) so subsequent file opens hit
+// the local working tree and don't require per-blob HTTP fetches. Returns
+// ("", noop, nil) when the data branch doesn't exist on the remote.
+func (b *gitBackend) cloneForRead() (string, func(), error) {
+	branch := b.dataBranch()
 	remoteURL, err := resolveTargetURL(b.opts)
 	if err != nil {
-		return nil, err
+		return "", func() {}, err
 	}
 	exists, err := branchExistsOnRemote(remoteURL, branch)
 	if err != nil {
-		return nil, err
+		return "", func() {}, err
 	}
 	if !exists {
-		return nil, nil
+		return "", func() {}, nil
 	}
 
 	workDir, err := os.MkdirTemp("", "defrost-read-")
 	if err != nil {
-		return nil, fmt.Errorf("mktemp: %w", err)
+		return "", func() {}, fmt.Errorf("mktemp: %w", err)
 	}
-	defer os.RemoveAll(workDir)
-	_ = os.Remove(workDir)
+	cleanup := func() { _ = os.RemoveAll(workDir) }
+	_ = os.Remove(workDir) // git clone wants the path absent
 
 	if _, err := runGit("", "clone", "--quiet", "--depth=1", "--single-branch", "--branch", branch, remoteURL, workDir); err != nil {
-		return nil, fmt.Errorf("clone data branch: %w", err)
+		cleanup()
+		return "", func() {}, fmt.Errorf("clone data branch: %w", err)
 	}
-	return readAllMetrics(workDir)
+	return workDir, cleanup, nil
 }
 
 // fileBackend writes spans/metrics to a plain directory; no git operations.
@@ -513,10 +525,7 @@ func (b *fileBackend) InsertNewRun(traces []*tracepb.ResourceSpans, metrics []*m
 	if err := b.InitialisePersistence(); err != nil {
 		return err
 	}
-	if err := appendSpans(b.dir, traces); err != nil {
-		return err
-	}
-	return appendMetrics(b.dir, metrics)
+	return writeRunFiles(b.dir, traces, metrics)
 }
 
 func (b *fileBackend) GetTestHistory(testName string) ([]*tracepb.ResourceSpans, error) {
@@ -526,7 +535,7 @@ func (b *fileBackend) GetTestHistory(testName string) ([]*tracepb.ResourceSpans,
 		}
 		return nil, err
 	}
-	return readSpansFromDir(b.dir, testName)
+	return readTestHistoryFromDir(b.dir, testName)
 }
 
 func (b *fileBackend) LoadAll() ([]*tracepb.ResourceSpans, map[string][]*tracepb.ResourceSpans, error) {
@@ -551,232 +560,497 @@ func (b *fileBackend) LoadAllMetrics() ([]*metricspb.ResourceMetrics, error) {
 
 // --- write helpers ---
 
-// protoMarshalCompact writes a single-line JSON encoding of a proto
-// message using the canonical OTLP/JSON form. We strip whitespace so each
-// line is one record (NDJSON discipline).
-var protoMarshal = protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: false}
+// zstdEncoder is shared across writes. Default compression level is fine
+// for text-heavy proto payloads with run metadata.
+var (
+	zstdEncoderOnce sync.Once
+	zstdEncoder     *zstd.Encoder
+	zstdEncoderErr  error
+)
 
+func sharedZstdEncoder() (*zstd.Encoder, error) {
+	zstdEncoderOnce.Do(func() {
+		zstdEncoder, zstdEncoderErr = zstd.NewWriter(nil)
+	})
+	return zstdEncoder, zstdEncoderErr
+}
+
+var (
+	zstdDecoderOnce sync.Once
+	zstdDecoder     *zstd.Decoder
+	zstdDecoderErr  error
+)
+
+func sharedZstdDecoder() (*zstd.Decoder, error) {
+	zstdDecoderOnce.Do(func() {
+		zstdDecoder, zstdDecoderErr = zstd.NewReader(nil)
+	})
+	return zstdDecoder, zstdDecoderErr
+}
+
+// writeSeed writes the README at branch creation time. We deliberately do
+// NOT write a `.gitattributes` with `merge=union` rules anymore: per-trace
+// files are writer-owned (one file per run, named by trace_id) so two
+// concurrent runs can never target the same path.
 func writeSeed(workDir string) error {
-	if err := os.WriteFile(filepath.Join(workDir, ".gitattributes"), []byte(gitAttributes), 0o644); err != nil {
-		return err
-	}
 	return os.WriteFile(filepath.Join(workDir, "README.md"), []byte(readme), 0o644)
 }
 
-func appendSpans(workDir string, traces []*tracepb.ResourceSpans) error {
-	if len(traces) == 0 {
-		return nil
-	}
-	dir := filepath.Join(workDir, "traces")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	for _, rs := range traces {
-		span := SpanFromResourceSpans(rs)
-		if span == nil {
-			continue
+// writeRunFiles is the single entry point used by both backends. It
+// writes at most one zstd-compressed OTLP/protobuf file under traces/ and
+// at most one under metrics/, partitioned by run-start UTC date.
+func writeRunFiles(workDir string, traces []*tracepb.ResourceSpans, metrics []*metricspb.ResourceMetrics) error {
+	if len(traces) > 0 {
+		if err := writeTraceFile(workDir, traces); err != nil {
+			return err
 		}
-		line, err := protoMarshal.Marshal(rs)
-		if err != nil {
-			return fmt.Errorf("marshal span %s: %w", span.Name, err)
-		}
-		line = bytes.ReplaceAll(line, []byte("\n"), []byte(" "))
-		path := filepath.Join(dir, EncodeName(span.Name)+".ndjson")
-		if err := appendLine(path, line); err != nil {
+	}
+	if len(metrics) > 0 {
+		if err := writeMetricsFile(workDir, traces, metrics); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func appendMetrics(workDir string, metrics []*metricspb.ResourceMetrics) error {
-	if len(metrics) == 0 {
-		return nil
+func writeTraceFile(workDir string, traces []*tracepb.ResourceSpans) error {
+	traceID, runStart := traceIdentityFromSpans(traces)
+	if len(traceID) == 0 {
+		return errors.New("write traces: no trace_id in run")
 	}
-	dir := filepath.Join(workDir, "metrics")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	for _, rm := range metrics {
-		m := MetricFromResourceMetrics(rm)
-		if m == nil {
-			continue
-		}
-		line, err := protoMarshal.Marshal(rm)
-		if err != nil {
-			return fmt.Errorf("marshal metric %s: %w", m.Name, err)
-		}
-		line = bytes.ReplaceAll(line, []byte("\n"), []byte(" "))
-		path := filepath.Join(dir, EncodeName(m.Name)+".ndjson")
-		if err := appendLine(path, line); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func appendLine(path string, line []byte) error {
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	data, err := marshalTraceRequest(traces)
 	if err != nil {
-		return fmt.Errorf("open %s: %w", path, err)
+		return fmt.Errorf("marshal traces: %w", err)
 	}
-	_, werr := f.Write(append(line, '\n'))
-	cerr := f.Close()
-	if werr != nil {
-		return fmt.Errorf("write %s: %w", path, werr)
+	compressed, err := compressZstd(data)
+	if err != nil {
+		return fmt.Errorf("compress traces: %w", err)
 	}
-	if cerr != nil {
-		return fmt.Errorf("close %s: %w", path, cerr)
+	path := tracePath(workDir, traceID, runStart)
+	return writeFileAtomic(path, compressed)
+}
+
+func writeMetricsFile(workDir string, traces []*tracepb.ResourceSpans, metrics []*metricspb.ResourceMetrics) error {
+	traceID, runStart := traceIdentityFromSpans(traces)
+	data, err := marshalMetricsRequest(metrics)
+	if err != nil {
+		return fmt.Errorf("marshal metrics: %w", err)
+	}
+	compressed, err := compressZstd(data)
+	if err != nil {
+		return fmt.Errorf("compress metrics: %w", err)
+	}
+	path := metricsPath(workDir, traceID, runStart)
+	return writeFileAtomic(path, compressed)
+}
+
+// traceIdentityFromSpans returns the run's trace_id and start time so the
+// caller can derive the date-partitioned filename. Reads from the root
+// span's TraceId / StartTimeUnixNano. Falls back to time.Now() if the root
+// span has no start time set (shouldn't happen on a real run, but keeps
+// the writer robust).
+func traceIdentityFromSpans(traces []*tracepb.ResourceSpans) ([]byte, time.Time) {
+	for _, rs := range traces {
+		for _, ss := range rs.ScopeSpans {
+			for _, s := range ss.Spans {
+				if s == nil || len(s.TraceId) == 0 {
+					continue
+				}
+				ns := int64(s.StartTimeUnixNano)
+				if ns == 0 {
+					return s.TraceId, time.Now().UTC()
+				}
+				return s.TraceId, time.Unix(0, ns).UTC()
+			}
+		}
+	}
+	return nil, time.Time{}
+}
+
+// marshalTraceRequest builds an ExportTraceServiceRequest carrying every
+// ResourceSpans the caller passed in, then proto-marshals it. This is the
+// canonical OTLP/Protobuf payload shape.
+func marshalTraceRequest(traces []*tracepb.ResourceSpans) ([]byte, error) {
+	req := &ctracepb.ExportTraceServiceRequest{ResourceSpans: traces}
+	return proto.Marshal(req)
+}
+
+// marshalMetricsRequest builds an ExportMetricsServiceRequest the same way
+// for metrics.
+func marshalMetricsRequest(metrics []*metricspb.ResourceMetrics) ([]byte, error) {
+	req := &cmetricspb.ExportMetricsServiceRequest{ResourceMetrics: metrics}
+	return proto.Marshal(req)
+}
+
+func compressZstd(data []byte) ([]byte, error) {
+	enc, err := sharedZstdEncoder()
+	if err != nil {
+		return nil, err
+	}
+	return enc.EncodeAll(data, nil), nil
+}
+
+func decompressZstd(data []byte) ([]byte, error) {
+	dec, err := sharedZstdDecoder()
+	if err != nil {
+		return nil, err
+	}
+	return dec.DecodeAll(data, nil)
+}
+
+// tracePath returns the date-partitioned absolute path for one run's
+// trace file: <workDir>/traces/<YYYY>/<MM>/<DD>/<hex trace_id>.otlp.pb.zst.
+func tracePath(workDir string, traceID []byte, runStart time.Time) string {
+	return signalPath(workDir, "traces", traceID, runStart)
+}
+
+// metricsPath is the metrics counterpart of tracePath.
+func metricsPath(workDir string, traceID []byte, runStart time.Time) string {
+	return signalPath(workDir, "metrics", traceID, runStart)
+}
+
+func signalPath(workDir, signal string, traceID []byte, runStart time.Time) string {
+	id := hex.EncodeToString(traceID)
+	if runStart.IsZero() {
+		runStart = time.Now().UTC()
+	}
+	y, m, d := runStart.UTC().Date()
+	return filepath.Join(workDir, signal,
+		fmt.Sprintf("%04d", y),
+		fmt.Sprintf("%02d", int(m)),
+		fmt.Sprintf("%02d", d),
+		id+fileSuffix,
+	)
+}
+
+// writeFileAtomic writes data to path atomically: write a sibling .tmp,
+// fsync the file, rename onto the final name, then fsync the parent dir
+// so the rename itself survives a crash. Directory fsync is a no-op on
+// macOS APFS / Windows but required on Linux ext4/xfs to make the rename
+// durable; calling it everywhere is cheap and harmless.
+func writeFileAtomic(path string, data []byte) (err error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmp)
+		}
+	}()
+	if _, err = f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(tmp, path); err != nil {
+		return err
+	}
+	if d, derr := os.Open(dir); derr == nil {
+		_ = d.Sync()
+		_ = d.Close()
 	}
 	return nil
 }
 
 // --- read helpers ---
 
-func readSpansFromDir(dir, testName string) ([]*tracepb.ResourceSpans, error) {
-	path := filepath.Join(dir, "traces", EncodeName(testName)+".ndjson")
-	f, err := os.Open(path)
-	if err != nil {
+// readTestHistoryFromDir walks every per-run trace file under dir/traces,
+// extracts spans whose Name matches testName, and returns them sorted
+// oldest-first by start time. Decoding is parallelised across CPU cores.
+func readTestHistoryFromDir(dir, testName string) ([]*tracepb.ResourceSpans, error) {
+	tracesDir := filepath.Join(dir, "traces")
+	if _, err := os.Stat(tracesDir); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	defer f.Close()
-
-	traces, err := parseSpansNDJSON(f)
+	var out []*tracepb.ResourceSpans
+	err := walkOTLPTraceFilesParallel(tracesDir, func(rss []*tracepb.ResourceSpans) {
+		for _, rs := range rss {
+			for _, ss := range rs.ScopeSpans {
+				for _, s := range ss.Spans {
+					if s.Name != testName {
+						continue
+					}
+					out = append(out, &tracepb.ResourceSpans{
+						Resource:   rs.Resource,
+						ScopeSpans: []*tracepb.ScopeSpans{{Scope: ss.Scope, Spans: []*tracepb.Span{s}}},
+					})
+				}
+			}
+		}
+	})
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(traces, func(i, j int) bool {
-		a := SpanFromResourceSpans(traces[i])
-		b := SpanFromResourceSpans(traces[j])
+	sort.Slice(out, func(i, j int) bool {
+		a := SpanFromResourceSpans(out[i])
+		b := SpanFromResourceSpans(out[j])
 		if a == nil || b == nil {
 			return false
 		}
 		return a.StartTimeUnixNano < b.StartTimeUnixNano
 	})
-	return traces, nil
+	return out, nil
 }
 
+// readAllSpans walks every per-run trace file, splits each into one
+// ResourceSpans per span, separates root spans from test spans, and
+// groups test spans by encoded span name (matching the existing serve-
+// layer key shape). Decoding is parallelised across CPU cores.
 func readAllSpans(dir string) ([]*tracepb.ResourceSpans, map[string][]*tracepb.ResourceSpans, error) {
 	tracesDir := filepath.Join(dir, "traces")
-	files, err := os.ReadDir(tracesDir)
-	if err != nil {
+	if _, err := os.Stat(tracesDir); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil, nil
 		}
 		return nil, nil, err
 	}
-	rootFile := EncodeName(rootSpanName) + ".ndjson"
 	var roots []*tracepb.ResourceSpans
 	byEncodedName := make(map[string][]*tracepb.ResourceSpans)
-	for _, f := range files {
-		if f.IsDir() || !strings.HasSuffix(f.Name(), ".ndjson") {
-			continue
+	err := walkOTLPTraceFilesParallel(tracesDir, func(rss []*tracepb.ResourceSpans) {
+		for _, rs := range rss {
+			for _, ss := range rs.ScopeSpans {
+				for _, s := range ss.Spans {
+					single := &tracepb.ResourceSpans{
+						Resource:   rs.Resource,
+						ScopeSpans: []*tracepb.ScopeSpans{{Scope: ss.Scope, Spans: []*tracepb.Span{s}}},
+					}
+					if s.Name == rootSpanName {
+						roots = append(roots, single)
+						continue
+					}
+					byEncodedName[EncodeName(s.Name)] = append(byEncodedName[EncodeName(s.Name)], single)
+				}
+			}
 		}
-		full := filepath.Join(tracesDir, f.Name())
-		fh, err := os.Open(full)
-		if err != nil {
-			return nil, nil, err
-		}
-		traces, err := parseSpansNDJSON(fh)
-		fh.Close()
-		if err != nil {
-			return nil, nil, fmt.Errorf("parse %s: %w", full, err)
-		}
-		if f.Name() == rootFile {
-			roots = append(roots, traces...)
-			continue
-		}
-		key := strings.TrimSuffix(f.Name(), ".ndjson")
-		byEncodedName[key] = traces
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 	return roots, byEncodedName, nil
 }
 
-func parseSpansNDJSON(r io.Reader) ([]*tracepb.ResourceSpans, error) {
-	var out []*tracepb.ResourceSpans
-	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 64*1024), 8*1024*1024)
-	for sc.Scan() {
-		line := bytes.TrimSpace(sc.Bytes())
-		if len(line) == 0 {
-			continue
-		}
-		rs := &tracepb.ResourceSpans{}
-		if err := protojson.Unmarshal(line, rs); err != nil {
-			return nil, fmt.Errorf("parse ndjson line: %w", err)
-		}
-		out = append(out, rs)
-	}
-	return out, sc.Err()
-}
-
+// readAllMetrics walks every per-run metrics file and returns one
+// *metricspb.ResourceMetrics per stored Metric (matching the existing
+// caller contract from the NDJSON era). Decoding is parallelised across
+// CPU cores.
 func readAllMetrics(dir string) ([]*metricspb.ResourceMetrics, error) {
 	metricsDir := filepath.Join(dir, "metrics")
-	files, err := os.ReadDir(metricsDir)
-	if err != nil {
+	if _, err := os.Stat(metricsDir); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, err
 	}
 	var out []*metricspb.ResourceMetrics
-	for _, f := range files {
-		if f.IsDir() || !strings.HasSuffix(f.Name(), ".ndjson") {
-			continue
+	err := walkOTLPMetricsFilesParallel(metricsDir, func(rms []*metricspb.ResourceMetrics) {
+		for _, rm := range rms {
+			out = append(out, SplitResourceMetrics(rm)...)
 		}
-		full := filepath.Join(metricsDir, f.Name())
-		fh, err := os.Open(full)
-		if err != nil {
-			return nil, err
-		}
-		records, err := parseMetricsNDJSON(fh)
-		fh.Close()
-		if err != nil {
-			return nil, fmt.Errorf("parse %s: %w", full, err)
-		}
-		out = append(out, records...)
+	})
+	if err != nil {
+		return nil, err
 	}
 	return out, nil
 }
 
-func parseMetricsNDJSON(r io.Reader) ([]*metricspb.ResourceMetrics, error) {
-	var out []*metricspb.ResourceMetrics
-	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 64*1024), 8*1024*1024)
-	for sc.Scan() {
-		line := bytes.TrimSpace(sc.Bytes())
-		if len(line) == 0 {
-			continue
+// listOTLPFiles returns every <root>/<YYYY>/<MM>/<DD>/<id>.otlp.pb.zst
+// path beneath root, in arbitrary order. Returns an empty slice if root
+// does not exist.
+func listOTLPFiles(root string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
 		}
-		rm := &metricspb.ResourceMetrics{}
-		if err := protojson.Unmarshal(line, rm); err != nil {
-			return nil, fmt.Errorf("parse ndjson line: %w", err)
+		if d.IsDir() {
+			return nil
 		}
-		out = append(out, rm)
+		if !strings.HasSuffix(d.Name(), fileSuffix) {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out, sc.Err()
+	return out, nil
+}
+
+// walkOTLPTraceFilesParallel decodes every trace file under root with a
+// worker pool sized to NumCPU, calling emit on the main goroutine for each
+// file's worth of decoded ResourceSpans. emit is serialised across
+// workers so the caller can mutate shared maps/slices without locks.
+func walkOTLPTraceFilesParallel(root string, emit func([]*tracepb.ResourceSpans)) error {
+	files, err := listOTLPFiles(root)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return nil
+	}
+	type result struct {
+		path string
+		rss  []*tracepb.ResourceSpans
+		err  error
+	}
+	jobs := make(chan string)
+	results := make(chan result)
+	workers := goruntime.NumCPU()
+	if workers > len(files) {
+		workers = len(files)
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for p := range jobs {
+				req, err := readOTLPTraceFile(p)
+				if err != nil {
+					results <- result{path: p, err: err}
+					continue
+				}
+				results <- result{path: p, rss: req.GetResourceSpans()}
+			}
+		}()
+	}
+	go func() {
+		for _, p := range files {
+			jobs <- p
+		}
+		close(jobs)
+		wg.Wait()
+		close(results)
+	}()
+	for r := range results {
+		if r.err != nil {
+			return fmt.Errorf("decode %s: %w", r.path, r.err)
+		}
+		emit(r.rss)
+	}
+	return nil
+}
+
+func walkOTLPMetricsFilesParallel(root string, emit func([]*metricspb.ResourceMetrics)) error {
+	files, err := listOTLPFiles(root)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return nil
+	}
+	type result struct {
+		path string
+		rms  []*metricspb.ResourceMetrics
+		err  error
+	}
+	jobs := make(chan string)
+	results := make(chan result)
+	workers := goruntime.NumCPU()
+	if workers > len(files) {
+		workers = len(files)
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for p := range jobs {
+				req, err := readOTLPMetricsFile(p)
+				if err != nil {
+					results <- result{path: p, err: err}
+					continue
+				}
+				results <- result{path: p, rms: req.GetResourceMetrics()}
+			}
+		}()
+	}
+	go func() {
+		for _, p := range files {
+			jobs <- p
+		}
+		close(jobs)
+		wg.Wait()
+		close(results)
+	}()
+	for r := range results {
+		if r.err != nil {
+			return fmt.Errorf("decode %s: %w", r.path, r.err)
+		}
+		emit(r.rms)
+	}
+	return nil
+}
+
+func readOTLPTraceFile(path string) (*ctracepb.ExportTraceServiceRequest, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := decompressZstd(raw)
+	if err != nil {
+		return nil, fmt.Errorf("zstd decode: %w", err)
+	}
+	req := &ctracepb.ExportTraceServiceRequest{}
+	if err := proto.Unmarshal(plain, req); err != nil {
+		return nil, fmt.Errorf("proto unmarshal: %w", err)
+	}
+	return req, nil
+}
+
+func readOTLPMetricsFile(path string) (*cmetricspb.ExportMetricsServiceRequest, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := decompressZstd(raw)
+	if err != nil {
+		return nil, fmt.Errorf("zstd decode: %w", err)
+	}
+	req := &cmetricspb.ExportMetricsServiceRequest{}
+	if err := proto.Unmarshal(plain, req); err != nil {
+		return nil, fmt.Errorf("proto unmarshal: %w", err)
+	}
+	return req, nil
 }
 
 func commitMessage(traces []*tracepb.ResourceSpans, metrics []*metricspb.ResourceMetrics) string {
 	short := ""
+	spanCount := 0
 	for _, rs := range traces {
-		span := SpanFromResourceSpans(rs)
-		if span == nil || span.Name != rootSpanName {
+		for _, ss := range rs.ScopeSpans {
+			spanCount += len(ss.Spans)
+		}
+		if short != "" {
 			continue
 		}
-		commit := models.ResourceString(rs.Resource, "vcs.repository.ref.revision")
-		if commit != "" {
+		if commit := models.ResourceString(rs.Resource, "vcs.repository.ref.revision"); commit != "" {
 			short = commit
 			if len(short) > 7 {
 				short = short[:7]
 			}
-			break
+			continue
 		}
-		runID := models.ResourceString(rs.Resource, "defrost.run_id")
-		if runID != "" {
+		if runID := models.ResourceString(rs.Resource, "cicd.pipeline.run.id"); runID != "" {
 			short = runID
 			if len(short) > 8 {
 				short = short[:8]
@@ -786,7 +1060,13 @@ func commitMessage(traces []*tracepb.ResourceSpans, metrics []*metricspb.Resourc
 	if short == "" {
 		short = "unknown"
 	}
-	return fmt.Sprintf("results for %s (%d spans, %d metrics)", short, len(traces), len(metrics))
+	metricCount := 0
+	for _, rm := range metrics {
+		for _, sm := range rm.ScopeMetrics {
+			metricCount += len(sm.Metrics)
+		}
+	}
+	return fmt.Sprintf("results for %s (%d spans, %d metrics)", short, spanCount, metricCount)
 }
 
 // --- preserved helpers (unchanged) ---

--- a/internal/persist/persist.go
+++ b/internal/persist/persist.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	DefaultDataBranch = "_defrost-v2"
+	DefaultDataBranch = "_defrost"
 
 	botName  = "defrost[bot]"
 	botEmail = "defrost[bot]@users.noreply.github.com"

--- a/internal/persist/persist_test.go
+++ b/internal/persist/persist_test.go
@@ -40,7 +40,7 @@ func TestEncodeName_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestPersist_WritesTracesAndMetricsOnFirstWrite(t *testing.T) {
+func TestPersist_WritesOneFilePerSignal(t *testing.T) {
 	requireGit(t)
 	repoDir, originURL := makeFixture(t)
 
@@ -72,95 +72,37 @@ func TestPersist_WritesTracesAndMetricsOnFirstWrite(t *testing.T) {
 
 	verify := cloneDataBranch(t, originURL)
 
-	tracesPath := filepath.Join(verify, "traces", EncodeName("github.com/x/p/TestA")+".ndjson")
-	if b, err := os.ReadFile(tracesPath); err != nil {
-		t.Errorf("missing %s: %v", tracesPath, err)
-	} else if !strings.Contains(string(b), run.RunID) {
-		t.Errorf("test span file should mention run id %q:\n%s", run.RunID, b)
+	traceFiles := listFilesWithSuffix(t, filepath.Join(verify, "traces"), fileSuffix)
+	if len(traceFiles) != 1 {
+		t.Fatalf("want exactly 1 trace file, got %d: %v", len(traceFiles), traceFiles)
 	}
-
-	rootPath := filepath.Join(verify, "traces", EncodeName("defrost.run")+".ndjson")
-	if b, err := os.ReadFile(rootPath); err != nil {
-		t.Errorf("missing root span file %s: %v", rootPath, err)
-	} else if !strings.Contains(string(b), run.RunID) {
-		t.Errorf("root span file missing run_id %q:\n%s", run.RunID, b)
+	metricFiles := listFilesWithSuffix(t, filepath.Join(verify, "metrics"), fileSuffix)
+	if len(metricFiles) != 1 {
+		t.Fatalf("want exactly 1 metrics file, got %d: %v", len(metricFiles), metricFiles)
 	}
-
-	metricsPath := filepath.Join(verify, "metrics", EncodeName("db.connection_pool.size")+".ndjson")
-	if b, err := os.ReadFile(metricsPath); err != nil {
-		t.Errorf("missing metrics file %s: %v", metricsPath, err)
-	} else if !strings.Contains(string(b), "db.connection_pool.size") {
-		t.Errorf("metric file missing name:\n%s", b)
-	}
-
-	if _, err := os.Stat(filepath.Join(verify, ".gitattributes")); err != nil {
-		t.Errorf("missing .gitattributes seed: %v", err)
+	if _, err := os.Stat(filepath.Join(verify, ".gitattributes")); err == nil {
+		t.Errorf(".gitattributes should not be written")
 	}
 	if _, err := os.Stat(filepath.Join(verify, "runs")); err == nil {
 		t.Errorf("runs/ directory should not exist")
 	}
-	if _, err := os.Stat(filepath.Join(verify, "tests")); err == nil {
-		t.Errorf("tests/ directory should not exist")
-	}
 }
 
-func TestPersist_AppendsToExistingBranch(t *testing.T) {
-	requireGit(t)
-	repoDir, originURL := makeFixture(t)
-
-	first := newRunContext("run-A", "1111111111111111", "main")
-	traces1 := WrapSpansInResource(first.Resource, []*tracepb.Span{
-		NewRootSpan(first),
-		makeTestSpan(first, "p/TestA", tracepb.Status_STATUS_CODE_OK),
-	})
-	if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces1, nil); err != nil {
-		t.Fatalf("first InsertNewRun: %v", err)
-	}
-
-	second := newRunContext("run-B", "2222222222222222", "main")
-	traces2 := WrapSpansInResource(second.Resource, []*tracepb.Span{
-		NewRootSpan(second),
-		makeTestSpan(second, "p/TestA", tracepb.Status_STATUS_CODE_ERROR),
-	})
-	if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces2, nil); err != nil {
-		t.Fatalf("second InsertNewRun: %v", err)
-	}
-
-	verify := cloneDataBranch(t, originURL)
-	path := filepath.Join(verify, "traces", EncodeName("p/TestA")+".ndjson")
-	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
-	}
-	lines := strings.Split(strings.TrimRight(string(b), "\n"), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 lines after two runs, got %d:\n%s", len(lines), b)
-	}
-	if !strings.Contains(lines[0], first.RunID) || !strings.Contains(lines[1], second.RunID) {
-		t.Errorf("expected one line per run id; got:\n%s", b)
-	}
-}
-
-func TestHistory_ReturnsSpansSortedByStartTime(t *testing.T) {
+func TestPersist_RoundTrip(t *testing.T) {
 	requireGit(t)
 	repoDir, _ := makeFixture(t)
 
-	run := newRunContext("run-history", "deadbeefcafebabe", "main")
+	run := newRunContext("run-rt", "deadbeefcafebabe", "main")
 	root := NewRootSpan(run)
-	span := &tracepb.Span{
-		TraceId:           run.TraceID,
-		SpanId:            mustHex8(),
-		ParentSpanId:      run.RootSpanID,
-		Name:              "github.com/x/p/TestA",
-		StartTimeUnixNano: 100,
-		EndTimeUnixNano:   200,
-		Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK},
-		Attributes: []*commonpb.KeyValue{
-			models.StringAttr("test.case.name", "github.com/x/p/TestA"),
-			models.StringAttr("defrost.run_id", run.RunID),
-		},
+	root.EndTimeUnixNano = uint64(int64(run.StartTimeUnixNano) + 100)
+	root.Status = &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK}
+
+	tests := []*tracepb.Span{
+		makeTestSpan(run, "github.com/x/p/TestA", tracepb.Status_STATUS_CODE_OK),
+		makeTestSpan(run, "github.com/x/p/TestB", tracepb.Status_STATUS_CODE_ERROR),
 	}
-	traces := WrapSpansInResource(run.Resource, []*tracepb.Span{root, span})
+	traces := WrapSpansInResource(run.Resource, append([]*tracepb.Span{root}, tests...))
+
 	if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces, nil); err != nil {
 		t.Fatalf("InsertNewRun: %v", err)
 	}
@@ -170,14 +112,271 @@ func TestHistory_ReturnsSpansSortedByStartTime(t *testing.T) {
 		t.Fatalf("GetTestHistory: %v", err)
 	}
 	if len(got) != 1 {
-		t.Fatalf("expected 1 span, got %d", len(got))
+		t.Fatalf("want 1 span for TestA, got %d", len(got))
 	}
 	gotSpan := SpanFromResourceSpans(got[0])
-	if gotSpan == nil || gotSpan.Name != "github.com/x/p/TestA" {
-		t.Errorf("name: %v", gotSpan)
+	if gotSpan == nil {
+		t.Fatal("got nil span")
+	}
+	if gotSpan.Name != "github.com/x/p/TestA" {
+		t.Errorf("name: %q", gotSpan.Name)
 	}
 	if rev := models.ResourceString(got[0].Resource, "vcs.repository.ref.revision"); rev != "deadbeefcafebabe" {
-		t.Errorf("resource not inlined: revision=%q", rev)
+		t.Errorf("resource not preserved through round-trip: revision=%q", rev)
+	}
+	if rid := models.ResourceString(got[0].Resource, "cicd.pipeline.run.id"); rid != run.RunID {
+		t.Errorf("cicd.pipeline.run.id missing on round-trip: %q", rid)
+	}
+}
+
+func TestPersist_AtomicWrite_NoTmpLeft(t *testing.T) {
+	requireGit(t)
+	repoDir, originURL := makeFixture(t)
+
+	run := newRunContext("run-tmp", "1234abcd5678ef00", "main")
+	traces := WrapSpansInResource(run.Resource, []*tracepb.Span{NewRootSpan(run)})
+	if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces, nil); err != nil {
+		t.Fatalf("InsertNewRun: %v", err)
+	}
+	verify := cloneDataBranch(t, originURL)
+
+	var leftovers []string
+	if err := filepath.Walk(verify, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		if strings.HasSuffix(info.Name(), ".tmp") {
+			leftovers = append(leftovers, p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Errorf("expected no .tmp files left, got: %v", leftovers)
+	}
+}
+
+func TestPersist_AtomicWrite_FailureLeavesNoPartial(t *testing.T) {
+	// Create a directory at the path we're about to write to. The .tmp
+	// write succeeds, but the final rename(tmp, target) fails because
+	// you can't rename a regular file over a non-empty directory. The
+	// deferred cleanup must remove the .tmp so no orphan is left.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "blocker")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	// Put something inside so rename can't succeed even on Linux's
+	// directory-overwrite-when-empty semantics.
+	if err := os.WriteFile(filepath.Join(target, "in-use"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := writeFileAtomic(target, []byte("payload")); err == nil {
+		t.Fatal("expected writeFileAtomic to fail when target path is a non-empty directory")
+	}
+
+	// No leftover .tmp anywhere under dir — proves the defer cleaned up.
+	var leftovers []string
+	_ = filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return err
+		}
+		if strings.HasSuffix(info.Name(), ".tmp") {
+			leftovers = append(leftovers, p)
+		}
+		return nil
+	})
+	if len(leftovers) != 0 {
+		t.Errorf("expected no .tmp orphans, got: %v", leftovers)
+	}
+}
+
+func TestPersist_SpanAttributesSlim(t *testing.T) {
+	requireGit(t)
+	repoDir, _ := makeFixture(t)
+
+	run := newRunContext("run-slim", "11111111aaaaaaaa", "main")
+	root := NewRootSpan(run)
+	test := makeTestSpan(run, "p/TestA", tracepb.Status_STATUS_CODE_OK)
+	traces := WrapSpansInResource(run.Resource, []*tracepb.Span{root, test})
+	if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces, nil); err != nil {
+		t.Fatalf("InsertNewRun: %v", err)
+	}
+
+	got, err := New(Options{RepoDir: repoDir}).GetTestHistory("p/TestA")
+	if err != nil || len(got) != 1 {
+		t.Fatalf("get test history: %v len=%d", err, len(got))
+	}
+	gotSpan := SpanFromResourceSpans(got[0])
+	if gotSpan == nil {
+		t.Fatal("nil span")
+	}
+	wantKeys := map[string]struct{}{"test.case.result.status": {}}
+	if len(gotSpan.Attributes) != len(wantKeys) {
+		t.Errorf("test span attribute count: want %d, got %d (%v)", len(wantKeys), len(gotSpan.Attributes), gotSpan.Attributes)
+	}
+	for _, kv := range gotSpan.Attributes {
+		if _, ok := wantKeys[kv.Key]; !ok {
+			t.Errorf("unexpected test span attribute: %q", kv.Key)
+		}
+	}
+
+	roots, _, err := New(Options{RepoDir: repoDir}).LoadAll()
+	if err != nil || len(roots) != 1 {
+		t.Fatalf("load all roots: %v len=%d", err, len(roots))
+	}
+	if rs := SpanFromResourceSpans(roots[0]); rs == nil {
+		t.Fatal("nil root span")
+	} else if len(rs.Attributes) != 0 {
+		t.Errorf("root span should have no attributes, got %v", rs.Attributes)
+	}
+}
+
+func TestPersist_FQNPreserved(t *testing.T) {
+	requireGit(t)
+	cases := []string{
+		"github.com/bjk95/defrost/internal/x/TestFoo",
+		"tests/test_module.py::TestClass::test_method",
+		"tests/test_module.py::test_top_level",
+		"src/components/Button.test.tsx > Button > renders",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			repoDir, _ := makeFixture(t)
+			run := newRunContext("run-"+EncodeName(name), "abc123def4567890", "main")
+			traces := WrapSpansInResource(run.Resource, []*tracepb.Span{
+				NewRootSpan(run),
+				makeTestSpan(run, name, tracepb.Status_STATUS_CODE_OK),
+			})
+			if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces, nil); err != nil {
+				t.Fatalf("InsertNewRun: %v", err)
+			}
+			got, err := New(Options{RepoDir: repoDir}).GetTestHistory(name)
+			if err != nil || len(got) != 1 {
+				t.Fatalf("get history: %v len=%d", err, len(got))
+			}
+			s := SpanFromResourceSpans(got[0])
+			if s == nil || s.Name != name {
+				t.Errorf("FQN not preserved: want %q got %q", name, s.GetName())
+			}
+		})
+	}
+}
+
+func TestPersist_ResourceCarriesCicdRunID(t *testing.T) {
+	requireGit(t)
+	repoDir, _ := makeFixture(t)
+	run := newRunContext("run-cicd", "1234567890abcdef", "main")
+	traces := WrapSpansInResource(run.Resource, []*tracepb.Span{
+		NewRootSpan(run),
+		makeTestSpan(run, "p/TestA", tracepb.Status_STATUS_CODE_OK),
+	})
+	if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces, nil); err != nil {
+		t.Fatalf("InsertNewRun: %v", err)
+	}
+	roots, _, err := New(Options{RepoDir: repoDir}).LoadAll()
+	if err != nil || len(roots) != 1 {
+		t.Fatalf("load: %v len=%d", err, len(roots))
+	}
+	if id := models.ResourceString(roots[0].Resource, "cicd.pipeline.run.id"); id != run.RunID {
+		t.Errorf("cicd.pipeline.run.id: want %q got %q", run.RunID, id)
+	}
+	if id := models.ResourceString(roots[0].Resource, "defrost.run_id"); id != "" {
+		t.Errorf("defrost.run_id should be absent, got %q", id)
+	}
+}
+
+func TestPersist_ConcurrentWritersDontConflict(t *testing.T) {
+	requireGit(t)
+	repoDir, originURL := makeFixture(t)
+
+	// Seed first run.
+	first := newRunContext("run-A", "1111111111111111", "main")
+	t1 := WrapSpansInResource(first.Resource, []*tracepb.Span{
+		NewRootSpan(first),
+		makeTestSpan(first, "p/TestA", tracepb.Status_STATUS_CODE_OK),
+	})
+	if err := New(Options{RepoDir: repoDir}).InsertNewRun(t1, nil); err != nil {
+		t.Fatalf("first InsertNewRun: %v", err)
+	}
+
+	// Second run from a different trace_id (different run id).
+	second := newRunContext("run-B", "2222222222222222", "main")
+	t2 := WrapSpansInResource(second.Resource, []*tracepb.Span{
+		NewRootSpan(second),
+		makeTestSpan(second, "p/TestA", tracepb.Status_STATUS_CODE_ERROR),
+	})
+	if err := New(Options{RepoDir: repoDir}).InsertNewRun(t2, nil); err != nil {
+		t.Fatalf("second InsertNewRun: %v", err)
+	}
+
+	verify := cloneDataBranch(t, originURL)
+	files := listFilesWithSuffix(t, filepath.Join(verify, "traces"), fileSuffix)
+	if len(files) != 2 {
+		t.Fatalf("want 2 trace files (one per run), got %d: %v", len(files), files)
+	}
+
+	got, err := New(Options{RepoDir: repoDir}).GetTestHistory("p/TestA")
+	if err != nil {
+		t.Fatalf("GetTestHistory: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("want 2 history rows for TestA, got %d", len(got))
+	}
+}
+
+func TestPersist_SizeBudget(t *testing.T) {
+	// Pin the headline win: a 100-test run should land well under 10 KB
+	// on disk (proto + zstd). Catches regressions where someone inflates
+	// per-span attributes again.
+	requireGit(t)
+	repoDir, originURL := makeFixture(t)
+
+	run := newRunContext("run-size", "deadbeefcafebabe", "main")
+	spans := []*tracepb.Span{NewRootSpan(run)}
+	for i := 0; i < 100; i++ {
+		spans = append(spans, makeTestSpan(run, "github.com/x/p/TestSize"+itoa(i), tracepb.Status_STATUS_CODE_OK))
+	}
+	traces := WrapSpansInResource(run.Resource, spans)
+	if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces, nil); err != nil {
+		t.Fatalf("InsertNewRun: %v", err)
+	}
+
+	verify := cloneDataBranch(t, originURL)
+	files := listFilesWithSuffix(t, filepath.Join(verify, "traces"), fileSuffix)
+	if len(files) != 1 {
+		t.Fatalf("want 1 file, got %d", len(files))
+	}
+	st, err := os.Stat(files[0])
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	const budget = 10 * 1024 // 10 KB hard ceiling for 100 spans.
+	if st.Size() > budget {
+		t.Errorf("100-span trace file too large: %d bytes (budget %d)", st.Size(), budget)
+	}
+}
+
+func TestPersist_DatePartitioning(t *testing.T) {
+	requireGit(t)
+	repoDir, originURL := makeFixture(t)
+
+	run := newRunContext("run-date", "abcdefabcdefabcd", "main")
+	// Pin the start time to a known UTC day so we can predict the path.
+	known := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	run.StartTimeUnixNano = known.UnixNano()
+	root := NewRootSpan(run)
+	root.StartTimeUnixNano = uint64(run.StartTimeUnixNano)
+	traces := WrapSpansInResource(run.Resource, []*tracepb.Span{root})
+	if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces, nil); err != nil {
+		t.Fatalf("InsertNewRun: %v", err)
+	}
+	verify := cloneDataBranch(t, originURL)
+	wantDir := filepath.Join(verify, "traces", "2026", "04", "15")
+	if _, err := os.Stat(wantDir); err != nil {
+		t.Errorf("expected date-partitioned dir %s: %v", wantDir, err)
 	}
 }
 
@@ -190,69 +389,6 @@ func TestHistory_UnknownTestReturnsEmpty(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("expected 0 spans, got %d", len(got))
-	}
-}
-
-func TestPushWithRetry_RebasesOnConflict(t *testing.T) {
-	requireGit(t)
-	repoDir, originURL := makeFixture(t)
-
-	seedRun := newRunContext("run-seed", "1111111111111111", "main")
-	seedTraces := WrapSpansInResource(seedRun.Resource, []*tracepb.Span{
-		NewRootSpan(seedRun),
-		makeTestSpan(seedRun, "p/TestA", tracepb.Status_STATUS_CODE_OK),
-	})
-	if err := New(Options{RepoDir: repoDir}).InsertNewRun(seedTraces, nil); err != nil {
-		t.Fatalf("seed InsertNewRun: %v", err)
-	}
-
-	w1Dir := filepath.Join(t.TempDir(), "w1")
-	branchExisted, err := openOrInitDataRepo(w1Dir, originURL, DefaultDataBranch)
-	if err != nil {
-		t.Fatalf("w1 openOrInit: %v", err)
-	}
-	if !branchExisted {
-		t.Fatal("w1: expected branch to exist after seed")
-	}
-	w1Run := newRunContext("run-w1", "2222222222222222", "main")
-	w1Traces := WrapSpansInResource(w1Run.Resource, []*tracepb.Span{
-		NewRootSpan(w1Run),
-		makeTestSpan(w1Run, "p/TestA", tracepb.Status_STATUS_CODE_ERROR),
-	})
-	if err := appendSpans(w1Dir, w1Traces); err != nil {
-		t.Fatalf("w1 appendSpans: %v", err)
-	}
-	if err := commitAll(w1Dir, "writer 1"); err != nil {
-		t.Fatalf("w1 commit: %v", err)
-	}
-
-	racerRun := newRunContext("run-racer", "3333333333333333", "main")
-	racerTraces := WrapSpansInResource(racerRun.Resource, []*tracepb.Span{
-		NewRootSpan(racerRun),
-		makeTestSpan(racerRun, "p/TestA", tracepb.Status_STATUS_CODE_OK),
-	})
-	if err := New(Options{RepoDir: repoDir}).InsertNewRun(racerTraces, nil); err != nil {
-		t.Fatalf("racer InsertNewRun: %v", err)
-	}
-
-	if err := pushWithRetry(w1Dir, DefaultDataBranch, true); err != nil {
-		t.Fatalf("pushWithRetry: %v", err)
-	}
-
-	verify := cloneDataBranch(t, originURL)
-	path := filepath.Join(verify, "traces", EncodeName("p/TestA")+".ndjson")
-	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read final ndjson: %v", err)
-	}
-	final := string(b)
-	for _, runID := range []string{"run-seed", "run-w1", "run-racer"} {
-		if !strings.Contains(final, runID) {
-			t.Errorf("expected run_id %s entry in final file:\n%s", runID, final)
-		}
-	}
-	if got := strings.Count(strings.TrimRight(final, "\n"), "\n") + 1; got != 3 {
-		t.Errorf("expected 3 lines after rebase, got %d:\n%s", got, final)
 	}
 }
 
@@ -292,61 +428,12 @@ func TestPersist_LocalOnlyNoRemote(t *testing.T) {
 		t.Fatalf("InsertNewRun (no-remote): %v", err)
 	}
 
-	out, err := exec.Command("git", "-C", dir, "show", DefaultDataBranch+":traces/"+EncodeName("p/TestA")+".ndjson").CombinedOutput()
+	got, err := New(Options{RepoDir: dir, NoRemote: true}).GetTestHistory("p/TestA")
 	if err != nil {
-		t.Fatalf("read traces file from data branch: %v: %s", err, out)
+		t.Fatalf("GetTestHistory: %v", err)
 	}
-	if !strings.Contains(string(out), run.RunID) {
-		t.Errorf("trace ndjson missing run_id %q:\n%s", run.RunID, out)
-	}
-}
-
-func TestPersist_LocalOnlyNoRemote_RelativeRepoDir(t *testing.T) {
-	requireGit(t)
-	parent := t.TempDir()
-	gitMust(t, "", "init", "-b", "main", filepath.Join(parent, "repo"))
-	gitMust(t, filepath.Join(parent, "repo"), "config", "user.email", "t@example.com")
-	gitMust(t, filepath.Join(parent, "repo"), "config", "user.name", "t")
-	gitMust(t, filepath.Join(parent, "repo"), "commit", "--allow-empty", "-m", "init")
-
-	t.Chdir(parent)
-
-	run := newRunContext("rel-run", "abc123", "main")
-	traces := WrapSpansInResource(run.Resource, []*tracepb.Span{NewRootSpan(run), makeTestSpan(run, "p/TestA", tracepb.Status_STATUS_CODE_OK)})
-	if err := New(Options{RepoDir: "repo", NoRemote: true}).InsertNewRun(traces, nil); err != nil {
-		t.Fatalf("InsertNewRun (no-remote, relative): %v", err)
-	}
-
-	out, err := exec.Command("git", "-C", "repo", "show", DefaultDataBranch+":traces/"+EncodeName("p/TestA")+".ndjson").CombinedOutput()
-	if err != nil {
-		t.Fatalf("read traces file from data branch: %v: %s", err, out)
-	}
-	if !strings.Contains(string(out), run.RunID) {
-		t.Errorf("trace ndjson missing run_id %q:\n%s", run.RunID, out)
-	}
-}
-
-func TestReadOriginURL_WorksInWorktree(t *testing.T) {
-	requireGit(t)
-	base := t.TempDir()
-	bareDir := filepath.Join(base, "origin.git")
-	repoDir := filepath.Join(base, "main")
-	wtDir := filepath.Join(base, "wt")
-
-	gitMust(t, "", "init", "--bare", bareDir)
-	gitMust(t, "", "init", "-b", "main", repoDir)
-	gitMust(t, repoDir, "remote", "add", "origin", bareDir)
-	gitMust(t, repoDir, "config", "user.email", "t@example.com")
-	gitMust(t, repoDir, "config", "user.name", "t")
-	gitMust(t, repoDir, "commit", "--allow-empty", "-m", "init")
-	gitMust(t, repoDir, "worktree", "add", "-b", "feature", wtDir)
-
-	url, err := readOriginURL(wtDir)
-	if err != nil {
-		t.Fatalf("readOriginURL in worktree: %v", err)
-	}
-	if url != bareDir {
-		t.Errorf("expected URL %q, got %q", bareDir, url)
+	if len(got) != 1 {
+		t.Errorf("want 1 history row, got %d", len(got))
 	}
 }
 
@@ -362,9 +449,9 @@ func TestPersist_DevModeWritesScratchDirAndSkipsGit(t *testing.T) {
 	}
 
 	scratch := filepath.Join(dir, DevDir)
-	tracesPath := filepath.Join(scratch, "traces", EncodeName("p/TestA")+".ndjson")
-	if _, err := os.Stat(tracesPath); err != nil {
-		t.Errorf("trace file not written to scratch dir: %v", err)
+	files := listFilesWithSuffix(t, filepath.Join(scratch, "traces"), fileSuffix)
+	if len(files) != 1 {
+		t.Errorf("want 1 dev trace file, got %d", len(files))
 	}
 	if out, err := exec.Command("git", "-C", dir, "rev-parse", "--verify", DefaultDataBranch).CombinedOutput(); err == nil {
 		t.Errorf("expected no %s branch, but rev-parse succeeded: %s", DefaultDataBranch, out)
@@ -403,7 +490,7 @@ func TestLoadAll_ReturnsRootSpansAndTestSpansGroupedByEncodedName(t *testing.T) 
 	}
 	gotRunIDs := map[string]bool{}
 	for _, rs := range roots {
-		if id := models.ResourceString(rs.Resource, "defrost.run_id"); id != "" {
+		if id := models.ResourceString(rs.Resource, "cicd.pipeline.run.id"); id != "" {
 			gotRunIDs[id] = true
 		}
 	}
@@ -574,13 +661,12 @@ func TestMetricResource_StripsHighCardinalityFields(t *testing.T) {
 	}
 	for _, kv := range mr.Attributes {
 		switch kv.Key {
-		case "defrost.run_id", "cicd.pipeline.run.id", "defrost.cmd",
+		case "cicd.pipeline.run.id", "defrost.cmd",
 			"vcs.repository.ref.revision", "defrost.dirty_hash",
 			"defrost.author_email", "defrost.author_name", "defrost.parent_commit":
 			t.Errorf("metric resource should not contain %q", kv.Key)
 		}
 	}
-	// Stable identity attrs should still be there.
 	if got := models.ResourceString(mr, "service.name"); got != "defrost" {
 		t.Errorf("service.name: %q", got)
 	}
@@ -596,7 +682,6 @@ func newRunContext(runID, commit, branch string) models.RunContext {
 		models.StringAttr("service.name", "defrost"),
 		models.StringAttr("vcs.repository.ref.revision", commit),
 		models.StringAttr("vcs.repository.ref.name", branch),
-		models.StringAttr("defrost.run_id", runID),
 		models.StringAttr("cicd.pipeline.run.id", runID),
 	}
 	return models.RunContext{
@@ -618,15 +703,23 @@ func makeTestSpan(run models.RunContext, name string, statusCode tracepb.Status_
 		EndTimeUnixNano:   uint64(run.StartTimeUnixNano + 5),
 		Status:            &tracepb.Status{Code: statusCode},
 		Attributes: []*commonpb.KeyValue{
-			models.StringAttr("test.case.name", name),
-			models.StringAttr("defrost.run_id", run.RunID),
+			models.StringAttr("test.case.result.status", statusToText(statusCode)),
 		},
 	}
 }
 
-func mustHex8() []byte {
-	return models.NewSpanID()
+func statusToText(c tracepb.Status_StatusCode) string {
+	switch c {
+	case tracepb.Status_STATUS_CODE_OK:
+		return "passed"
+	case tracepb.Status_STATUS_CODE_ERROR:
+		return "failed"
+	default:
+		return "skipped"
+	}
 }
+
+func mustHex8() []byte { return models.NewSpanID() }
 
 func requireGit(t *testing.T) {
 	t.Helper()
@@ -663,4 +756,37 @@ func cloneDataBranch(t *testing.T, originURL string) string {
 	dir := filepath.Join(t.TempDir(), "verify")
 	gitMust(t, "", "clone", "--quiet", "--single-branch", "--branch", DefaultDataBranch, originURL, dir)
 	return dir
+}
+
+func listFilesWithSuffix(t *testing.T, root, suffix string) []string {
+	t.Helper()
+	var out []string
+	if _, err := os.Stat(root); err != nil {
+		return out
+	}
+	if err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		if strings.HasSuffix(info.Name(), suffix) {
+			out = append(out, p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	digits := "0123456789"
+	out := ""
+	for i > 0 {
+		out = string(digits[i%10]) + out
+		i /= 10
+	}
+	return out
 }

--- a/internal/serve/data_test.go
+++ b/internal/serve/data_test.go
@@ -17,7 +17,7 @@ func TestLoad_SortsRunsNewestFirstAndCapsAtFifty(t *testing.T) {
 	for i := 0; i < 60; i++ {
 		roots = append(roots, &tracepb.ResourceSpans{
 			Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
-				models.StringAttr("defrost.run_id", idFor(i)),
+				models.StringAttr("cicd.pipeline.run.id", idFor(i)),
 			}},
 			ScopeSpans: []*tracepb.ScopeSpans{{
 				Spans: []*tracepb.Span{{
@@ -47,7 +47,7 @@ func TestLoad_SortsRunsNewestFirstAndCapsAtFifty(t *testing.T) {
 	if len(ds.Roots) != 50 {
 		t.Errorf("want 50 roots after cap, got %d", len(ds.Roots))
 	}
-	if rid := models.ResourceString(ds.Roots[0].Resource, "defrost.run_id"); rid != idFor(59) {
+	if rid := models.ResourceString(ds.Roots[0].Resource, "cicd.pipeline.run.id"); rid != idFor(59) {
 		t.Errorf("want newest root first, got %q", rid)
 	}
 	// Span whose run_id is no longer in the capped set must be dropped.
@@ -58,16 +58,17 @@ func TestLoad_SortsRunsNewestFirstAndCapsAtFifty(t *testing.T) {
 	if survivor == nil {
 		t.Fatal("survivor span unexpectedly nil")
 	}
-	if rid := models.AttrString(survivor.Attributes, "defrost.run_id"); rid != idFor(59) {
+	if rid := models.ResourceString(ds.TestSpans["tid-A"][0].Resource, "cicd.pipeline.run.id"); rid != idFor(59) {
 		t.Errorf("want surviving span to reference run %q, got %q", idFor(59), rid)
 	}
+	_ = survivor
 }
 
 func TestLoad_PassesMetricsThroughUnfiltered(t *testing.T) {
 	roots := []*tracepb.ResourceSpans{
 		{
 			Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
-				models.StringAttr("defrost.run_id", "run-1"),
+				models.StringAttr("cicd.pipeline.run.id", "run-1"),
 			}},
 			ScopeSpans: []*tracepb.ScopeSpans{{
 				Spans: []*tracepb.Span{{Name: "defrost.run", StartTimeUnixNano: 10}},
@@ -126,12 +127,14 @@ func TestLoad_PassesMetricsThroughUnfiltered(t *testing.T) {
 
 func testRSWithRun(runID, status string, startNs uint64) *tracepb.ResourceSpans {
 	return &tracepb.ResourceSpans{
+		Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
+			models.StringAttr("cicd.pipeline.run.id", runID),
+		}},
 		ScopeSpans: []*tracepb.ScopeSpans{{
 			Spans: []*tracepb.Span{{
 				Name:              "pkg.TestA",
 				StartTimeUnixNano: startNs,
 				Attributes: []*commonpb.KeyValue{
-					models.StringAttr("defrost.run_id", runID),
 					models.StringAttr("test.case.result.status", status),
 				},
 			}},

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -246,21 +246,15 @@ func lookupEntry(ds Dataset, tid, rid string) (entryDTO, runDetailDTO, bool) {
 	return entryDTO{}, runDetailDTO{}, false
 }
 
-// runIDOf reads the defrost.run_id from either the ResourceSpans's
-// Resource (preferred for root spans) or the contained Span's Attributes
-// (preferred for test spans).
+// runIDOf reads the run id from a ResourceSpans's Resource, using OTel's
+// `cicd.pipeline.run.id` semconv key. Schema 4 stores this only on the
+// Resource — never on individual spans — so there is no span-attribute
+// fallback.
 func runIDOf(rs *tracepb.ResourceSpans) string {
 	if rs == nil {
 		return ""
 	}
-	if id := models.ResourceString(rs.Resource, "defrost.run_id"); id != "" {
-		return id
-	}
-	span := persist.SpanFromResourceSpans(rs)
-	if span == nil {
-		return ""
-	}
-	return models.AttrString(span.Attributes, "defrost.run_id")
+	return models.ResourceString(rs.Resource, "cicd.pipeline.run.id")
 }
 
 func spanToEntryDTO(rs *tracepb.ResourceSpans) entryDTO {
@@ -318,7 +312,7 @@ func rootSpanToRunDTO(rs *tracepb.ResourceSpans) runDetailDTO {
 		}
 	}
 	return runDetailDTO{
-		RunID:       models.ResourceString(rs.Resource, "defrost.run_id"),
+		RunID:       models.ResourceString(rs.Resource, "cicd.pipeline.run.id"),
 		Commit:      models.ResourceString(rs.Resource, "vcs.repository.ref.revision"),
 		Parent:      models.ResourceString(rs.Resource, "defrost.parent_commit"),
 		Branch:      models.ResourceString(rs.Resource, "vcs.repository.ref.name"),

--- a/internal/serve/server_test.go
+++ b/internal/serve/server_test.go
@@ -22,7 +22,7 @@ func stubDataset() Dataset {
 		Roots: []*tracepb.ResourceSpans{
 			{
 				Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
-					models.StringAttr("defrost.run_id", "run-2"),
+					models.StringAttr("cicd.pipeline.run.id", "run-2"),
 					models.StringAttr("vcs.repository.ref.revision", "deadbee"),
 					models.StringAttr("vcs.repository.ref.name", "main"),
 				}},
@@ -35,7 +35,7 @@ func stubDataset() Dataset {
 			},
 			{
 				Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
-					models.StringAttr("defrost.run_id", "run-1"),
+					models.StringAttr("cicd.pipeline.run.id", "run-1"),
 					models.StringAttr("vcs.repository.ref.revision", "cafebab"),
 					models.StringAttr("vcs.repository.ref.name", "main"),
 				}},
@@ -62,7 +62,6 @@ func makeTestRS(name, runID, status string, startNs, endNs uint64, output string
 		StartTimeUnixNano: startNs,
 		EndTimeUnixNano:   endNs,
 		Attributes: []*commonpb.KeyValue{
-			models.StringAttr("defrost.run_id", runID),
 			models.StringAttr("test.case.result.status", status),
 		},
 	}
@@ -73,6 +72,9 @@ func makeTestRS(name, runID, status string, startNs, endNs uint64, output string
 		}}
 	}
 	return &tracepb.ResourceSpans{
+		Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
+			models.StringAttr("cicd.pipeline.run.id", runID),
+		}},
 		ScopeSpans: []*tracepb.ScopeSpans{{Spans: []*tracepb.Span{span}}},
 	}
 }
@@ -188,7 +190,7 @@ func TestServer_GetTestRun_HandlesDoubleEncodedTestIDs(t *testing.T) {
 	ds := Dataset{
 		Roots: []*tracepb.ResourceSpans{{
 			Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
-				models.StringAttr("defrost.run_id", "run-1"),
+				models.StringAttr("cicd.pipeline.run.id", "run-1"),
 			}},
 			ScopeSpans: []*tracepb.ScopeSpans{{
 				Spans: []*tracepb.Span{{Name: "defrost.run", StartTimeUnixNano: 1}},
@@ -219,7 +221,7 @@ func TestServer_GetMetrics_TranslatesGaugeAndHistogram(t *testing.T) {
 	traceID := models.DeriveTraceID(runID)
 
 	rootResource := &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
-		models.StringAttr("defrost.run_id", runID),
+		models.StringAttr("cicd.pipeline.run.id", runID),
 	}}
 	root := &tracepb.ResourceSpans{
 		Resource: rootResource,
@@ -341,7 +343,7 @@ func TestServer_GetMetrics_DropsDataPointsWithoutKeptRun(t *testing.T) {
 
 	root := &tracepb.ResourceSpans{
 		Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
-			models.StringAttr("defrost.run_id", runID),
+			models.StringAttr("cicd.pipeline.run.id", runID),
 		}},
 		ScopeSpans: []*tracepb.ScopeSpans{{
 			Spans: []*tracepb.Span{{Name: "defrost.run", StartTimeUnixNano: 1}},
@@ -387,7 +389,7 @@ func TestServer_GetMetrics_TimeWindowFallbackForExemplarlessPoints(t *testing.T)
 	// Run window: [1000, 2000].
 	root := &tracepb.ResourceSpans{
 		Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
-			models.StringAttr("defrost.run_id", "run-1"),
+			models.StringAttr("cicd.pipeline.run.id", "run-1"),
 		}},
 		ScopeSpans: []*tracepb.ScopeSpans{{
 			Spans: []*tracepb.Span{{


### PR DESCRIPTION
## Summary

Schema 4 hard-cut. Each `defrost exec` invocation now produces:

- one zstd-compressed OTLP/Protobuf file at `traces/<YYYY>/<MM>/<DD>/<trace_id>.otlp.pb.zst`
- one matching file at `metrics/<YYYY>/<MM>/<DD>/<trace_id>.otlp.pb.zst` (when metrics are present)

Each file's contents are a canonical `ExportTraceServiceRequest` /
`ExportMetricsServiceRequest` carrying every span / metric for the run.

### Highlights

- **Writer-owned filenames** (one file per run, named by `trace_id`) — two concurrent runs can never target the same path, so the `.gitattributes merge=union` driver is gone.
- **Atomic writes**: write sibling `.tmp`, fsync, rename, then fsync the parent dir so the rename itself survives a crash on Linux ext4/xfs. Cleans up `.tmp` orphans on every failure path.
- **Run-scoped attributes** live exactly once per file on the Resource. `span.Name` is the canonical fully qualified test name; lossy projections (`test.case.name`, `test.suite.name`, `code.namespace`, `code.function`) are no longer stored.
- **`defrost.run_id`** Resource attribute removed; **`cicd.pipeline.run.id`** is now the sole OTel-semconv-aligned run identifier.
- **Default data branch** stays `_defrost` — same name, new format. The old branch needs to be wiped before deploying this PR (see Migration).
- **Read path** decodes files in parallel (`NumCPU` workers) and splits per-run files back into one `ResourceSpans` per span so existing callers (history, dashboard, run resolver) keep working unchanged.
- **Expected size**: ~2–3 KB for a 100-test run vs ~100 KB on the old NDJSON layout (≈30–50× reduction). Pinned by a `TestPersist_SizeBudget` test set to a 10 KB hard ceiling.

### Out of scope (deferred to follow-ups)

Compaction (collapsing N per-run files into one daily file), trained zstd dictionary, self-dogfooded benchmark with CI gate, persistent inverted indices for per-test history, GitHub Git Data API fast path, sparse-checkout date-window reads, zstd level tuning.

### Migration

Hard cut on the data format, but the branch name is unchanged. Delete the existing `_defrost` branch on origin before/after merging this PR — running CI under the new code will recreate it fresh. Old NDJSON-format data is not migrated.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` passes
- [x] CI green on all 6 jobs (go unit tests, pytest, jest js, jest ts, promptfoo, inspect-ai)
- [x] New tests:
  - `TestPersist_WritesOneFilePerSignal` — exactly one trace + one metrics file per `InsertNewRun`
  - `TestPersist_RoundTrip` — write → decompress → unmarshal → resource preserved
  - `TestPersist_AtomicWrite_NoTmpLeft` — happy path leaves no `.tmp` orphans
  - `TestPersist_AtomicWrite_FailureLeavesNoPartial` — rename failure cleans up `.tmp`
  - `TestPersist_SpanAttributesSlim` — exactly `{test.case.result.status}` on test spans, no attrs on root
  - `TestPersist_FQNPreserved` — table over Go / pytest-with-class / pytest-without-class / jest names; round-trips byte-for-byte through `span.Name`
  - `TestPersist_ResourceCarriesCicdRunID` — `cicd.pipeline.run.id` present, `defrost.run_id` absent
  - `TestPersist_ConcurrentWritersDontConflict` — two runs land as two distinct files; no merge driver involved
  - `TestPersist_SizeBudget` — 100-span run < 10 KB on disk
  - `TestPersist_DatePartitioning` — file lands under expected `traces/YYYY/MM/DD/` for a fixed run start time
- [x] Updated existing tests (`persist_test.go`, `exec_test.go`, `internal/serve/*_test.go`, `internal/otlp/translate_test.go`) for the slim attribute set and the `cicd.pipeline.run.id` rename
