### PR TITLE
feat(cli): add `defrost drop history`; remove --no-remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,61 @@ Manage the suppression list. When every failing test in a run is suppressed,
 defrost rewrites the exit code to 0 — anything outside the list (a new
 failure, a build error, a panic) still exits non-zero.
 
+### `defrost drop history`
+
+Defrost is append-only — every run adds one trace and one metrics file to
+the data branch. Over months that branch grows. `defrost drop history`
+permanently deletes persisted traces and metrics and rewrites the branch
+so git can actually reclaim the space.
+
+```sh
+# Drop everything. Shows an inventory and asks before touching anything.
+defrost drop history
+
+# Drop only one signal.
+defrost drop history --traces-only
+defrost drop history --metrics-only
+
+# Skip the prompt (CI / scripts).
+defrost drop history --yes
+
+# Wipe the local scratch dir from `--dev` runs.
+defrost drop history --dev
+```
+
+You'll see:
+
+```
+About to drop history on branch _defrost (origin: git@github.com:you/repo.git):
+  traces:  142 files, 18.4 MB  (2024-09-12 → 2026-04-29)
+  metrics: 142 files,  4.2 MB  (2024-09-12 → 2026-04-29)
+
+This rewrites the branch via orphan commit + force-push and is irreversible.
+Preserved: suppressions.json (37 entries), README.md.
+
+Type "drop" to confirm:
+```
+
+**What's preserved.** Suppressions, the data-branch `README.md`, and
+whichever signal you didn't drop (e.g. metrics, when you used
+`--traces-only`).
+
+**How space gets reclaimed.** Defrost replaces the data branch with a
+single new commit containing only the kept files. Old commits become
+unreachable and the remote (GitHub, GitLab, …) garbage-collects them over
+time. Local clones of the data branch keep their old objects until the
+next `git gc` — `defrost serve` always re-clones from origin, so the
+dashboard reflects the rewritten state immediately.
+
+**Concurrency.** If someone else's `defrost exec` lands between the
+confirmation and the push, defrost aborts with a clear error rather than
+overwriting their data. Re-run `defrost drop history` and the new run
+shows up in the inventory.
+
+**Nothing to drop.** If the data branch doesn't exist yet, or there are
+zero files for the selectors you chose, defrost prints a one-line
+explanation and exits 0 without prompting.
+
 ### `defrost serve`
 
 Serves the dashboard at `127.0.0.1:6969` (override with `--port`).
@@ -106,6 +161,10 @@ OTel `trace_id`).
 
 To experiment without touching git, pass `--no-persist` (don't store
 anything) or `--dev` (write to `.defrost-dev/` instead of the data branch).
+
+When the branch grows large enough to matter, use
+[`defrost drop history`](#defrost-drop-history) to rewrite it and reclaim
+space. Suppressions are preserved.
 
 ### Under the hood
 

--- a/cli.go
+++ b/cli.go
@@ -6,7 +6,6 @@ var CLI struct {
 		RepoDir    string   `name:"repo-dir" default:"." help:"Path to the git repo to persist into."`
 		DataBranch string   `name:"data-branch" default:"_defrost" help:"Branch name where results are stored."`
 		NoPersist  bool     `name:"no-persist" help:"Run tests without persisting results."`
-		NoRemote   bool     `name:"no-remote" help:"Persist locally only — store the data branch in the local repo and do not push."`
 		Dev        bool     `name:"dev" short:"d" help:"Dev mode: write results to <repo-dir>/.defrost-dev (gitignored scratch dir) instead of committing/pushing. For developing defrost itself."`
 	} `cmd:"" help:"Execute test command and persist results."`
 
@@ -14,7 +13,7 @@ var CLI struct {
 		Test       string `arg:"" name:"test" help:"Full test name (package + test, e.g. github.com/x/p/TestA)."`
 		RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
 		DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name to read from."`
-		NoRemote   bool   `name:"no-remote" help:"Read from the local repo only — do not consult origin."`
+		Dev        bool   `name:"dev" short:"d" help:"Dev mode: read the local scratch dir instead of the data branch."`
 	} `cmd:"" help:"Print recorded history for a single test as NDJSON."`
 
 	Suppress struct {
@@ -22,7 +21,6 @@ var CLI struct {
 			Tests      []string `arg:"" name:"tests" help:"One or more test IDs to suppress (same form as 'defrost history'). All IDs land in a single commit on the data branch."`
 			RepoDir    string   `name:"repo-dir" default:"." help:"Path to the git repo."`
 			DataBranch string   `name:"data-branch" default:"_defrost" help:"Branch name where suppressions are stored."`
-			NoRemote   bool     `name:"no-remote" help:"Write to the local repo only — do not push."`
 			Dev        bool     `name:"dev" short:"d" help:"Dev mode: read/write the local scratch dir instead of the data branch."`
 		} `cmd:"" help:"Add one or more test IDs to the suppression list."`
 
@@ -30,22 +28,31 @@ var CLI struct {
 			Test       string `arg:"" name:"test" help:"Full test ID to remove from the suppression list."`
 			RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
 			DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name where suppressions are stored."`
-			NoRemote   bool   `name:"no-remote" help:"Write to the local repo only — do not push."`
 			Dev        bool   `name:"dev" short:"d" help:"Dev mode: read/write the local scratch dir instead of the data branch."`
 		} `cmd:"" help:"Remove a test from the suppression list."`
 
 		List struct {
 			RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
 			DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name to read from."`
-			NoRemote   bool   `name:"no-remote" help:"Read from the local repo only — do not consult origin."`
 			Dev        bool   `name:"dev" short:"d" help:"Dev mode: read the local scratch dir instead of the data branch."`
 		} `cmd:"" help:"List the suppressed test IDs, one per line."`
 	} `cmd:"" help:"Manage the suppression list. When every failing test in 'defrost exec' is suppressed, the exit code is rewritten to 0."`
+
+	Drop struct {
+		History struct {
+			TracesOnly  bool   `name:"traces-only" help:"Drop only traces; keep metrics."`
+			MetricsOnly bool   `name:"metrics-only" help:"Drop only metrics; keep traces."`
+			Yes         bool   `name:"yes" short:"y" help:"Skip the confirmation prompt."`
+			RepoDir     string `name:"repo-dir" default:"." help:"Path to the git repo."`
+			DataBranch  string `name:"data-branch" default:"_defrost" help:"Branch name to rewrite."`
+			Dev         bool   `name:"dev" short:"d" help:"Dev mode: drop from the local scratch dir instead of the data branch."`
+		} `cmd:"" help:"Drop persisted traces and/or metrics, rewriting the data branch via orphan commit + force-push so old objects can be garbage-collected. Suppressions are preserved."`
+	} `cmd:"" help:"Destructive operations on the data branch."`
 
 	Serve struct {
 		Port       int    `name:"port" default:"6969" help:"Port to bind on 127.0.0.1."`
 		RepoDir    string `name:"repo-dir" default:"." help:"Path to the git repo."`
 		DataBranch string `name:"data-branch" default:"_defrost" help:"Branch name to read from."`
-		NoRemote   bool   `name:"no-remote" help:"Read from the local repo only — do not consult origin."`
+		Dev        bool   `name:"dev" short:"d" help:"Dev mode: read the local scratch dir instead of the data branch."`
 	} `cmd:"" help:"Serve a local UI for inspecting test history."`
 }

--- a/drop.go
+++ b/drop.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -77,9 +78,23 @@ func dropLocation(plan persist.DropPlan) string {
 		return ".defrost-dev/"
 	}
 	if plan.OriginURL != "" {
-		return fmt.Sprintf("branch %s (origin: %s)", plan.Branch, plan.OriginURL)
+		return fmt.Sprintf("branch %s (origin: %s)", plan.Branch, sanitizeOriginURL(plan.OriginURL))
 	}
 	return fmt.Sprintf("branch %s", plan.Branch)
+}
+
+// sanitizeOriginURL strips userinfo from the origin URL so an embedded
+// token in an HTTPS remote (e.g. https://<pat>@github.com/foo/bar.git or
+// https://user:pass@host/...) doesn't leak into the confirmation prompt
+// or, with --yes, into CI logs. SCP-style SSH remotes (git@host:path)
+// don't parse as URLs and pass through unchanged; they carry no secret.
+func sanitizeOriginURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.User == nil {
+		return raw
+	}
+	u.User = nil
+	return u.String()
 }
 
 func printDropPlan(w *os.File, plan persist.DropPlan) {

--- a/drop.go
+++ b/drop.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bjk95/defrost/internal/persist"
+)
+
+type DropOpts struct {
+	RepoDir     string
+	DataBranch  string
+	TracesOnly  bool
+	MetricsOnly bool
+	Yes         bool
+	Dev         bool
+}
+
+func HandleDropHistory(opts DropOpts) int {
+	if opts.TracesOnly && opts.MetricsOnly {
+		fmt.Fprintln(os.Stderr, "drop history: --traces-only and --metrics-only are mutually exclusive")
+		return 2
+	}
+	sel := persist.DropSelector{
+		DropTraces:  !opts.MetricsOnly,
+		DropMetrics: !opts.TracesOnly,
+	}
+
+	be := persist.New(persist.Options{
+		RepoDir:    opts.RepoDir,
+		DataBranch: opts.DataBranch,
+		AuthToken:  os.Getenv("GITHUB_TOKEN"),
+		Dev:        opts.Dev,
+	})
+
+	confirm := func(plan persist.DropPlan) bool {
+		if plan.BranchMissing {
+			fmt.Fprintf(os.Stderr, "nothing to drop: data branch %q does not exist on origin.\n", plan.Branch)
+			return false
+		}
+		if plan.Nothing() {
+			fmt.Fprintln(os.Stderr, nothingToDropMessage(plan))
+			return false
+		}
+		printDropPlan(os.Stderr, plan)
+		if opts.Yes {
+			return true
+		}
+		return askDropConfirmation(os.Stdin, os.Stderr)
+	}
+
+	if err := be.DropHistory(sel, confirm); err != nil {
+		fmt.Fprintln(os.Stderr, "drop history:", err)
+		return 1
+	}
+	return 0
+}
+
+func nothingToDropMessage(plan persist.DropPlan) string {
+	loc := dropLocation(plan)
+	switch {
+	case plan.Sel.DropTraces && plan.Sel.DropMetrics:
+		return fmt.Sprintf("nothing to drop: %s has no traces or metrics persisted.", loc)
+	case plan.Sel.DropTraces:
+		return fmt.Sprintf("nothing to drop: %s has no traces persisted.", loc)
+	case plan.Sel.DropMetrics:
+		return fmt.Sprintf("nothing to drop: %s has no metrics persisted.", loc)
+	}
+	return fmt.Sprintf("nothing to drop: %s.", loc)
+}
+
+func dropLocation(plan persist.DropPlan) string {
+	if plan.Dev {
+		return ".defrost-dev/"
+	}
+	if plan.OriginURL != "" {
+		return fmt.Sprintf("branch %s (origin: %s)", plan.Branch, plan.OriginURL)
+	}
+	return fmt.Sprintf("branch %s", plan.Branch)
+}
+
+func printDropPlan(w *os.File, plan persist.DropPlan) {
+	fmt.Fprintf(w, "About to drop history on %s:\n", dropLocation(plan))
+	if plan.Sel.DropTraces {
+		fmt.Fprintf(w, "  traces:  %s\n", formatSignalLine(plan.TraceFiles, plan.TraceBytes, plan.OldestRunUTC, plan.NewestRunUTC))
+	} else {
+		fmt.Fprintf(w, "  traces:  preserved (%d files, %s)\n", plan.TraceFiles, humanBytes(plan.TraceBytes))
+	}
+	if plan.Sel.DropMetrics {
+		fmt.Fprintf(w, "  metrics: %s\n", formatSignalLine(plan.MetricFiles, plan.MetricBytes, plan.OldestRunUTC, plan.NewestRunUTC))
+	} else {
+		fmt.Fprintf(w, "  metrics: preserved (%d files, %s)\n", plan.MetricFiles, humanBytes(plan.MetricBytes))
+	}
+	fmt.Fprintln(w)
+	if plan.Dev {
+		fmt.Fprintln(w, "This permanently deletes the files. Suppressions and README are preserved.")
+	} else {
+		fmt.Fprintln(w, "This rewrites the branch via orphan commit + force-push and is irreversible.")
+	}
+	fmt.Fprintf(w, "Preserved: suppressions.json (%d entries), README.md.\n", plan.SuppressionsN)
+	fmt.Fprintln(w)
+}
+
+func formatSignalLine(files int, bytes int64, oldest, newest time.Time) string {
+	dateRange := ""
+	if !oldest.IsZero() && !newest.IsZero() {
+		dateRange = fmt.Sprintf("  (%s → %s)", oldest.Format("2006-01-02"), newest.Format("2006-01-02"))
+	}
+	return fmt.Sprintf("%d files, %s%s", files, humanBytes(bytes), dateRange)
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for c := n / unit; c >= unit; c /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+func askDropConfirmation(in *os.File, out *os.File) bool {
+	fmt.Fprint(out, `Type "drop" to confirm: `)
+	scanner := bufio.NewScanner(in)
+	if !scanner.Scan() {
+		fmt.Fprintln(out, "cancelled.")
+		return false
+	}
+	if strings.TrimSpace(scanner.Text()) != "drop" {
+		fmt.Fprintln(out, "cancelled.")
+		return false
+	}
+	return true
+}

--- a/drop_test.go
+++ b/drop_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bjk95/defrost/internal/persist"
+)
+
+func TestSanitizeOriginURL_StripsCredentials(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"https with token-as-user", "https://ghp_AbcDef@github.com/foo/bar.git", "https://github.com/foo/bar.git"},
+		{"https with user:password", "https://user:pass@github.com/foo/bar.git", "https://github.com/foo/bar.git"},
+		{"https with x-access-token", "https://x-access-token:ghp_xyz@github.com/foo/bar.git", "https://github.com/foo/bar.git"},
+		{"plain https unchanged", "https://github.com/foo/bar.git", "https://github.com/foo/bar.git"},
+		{"scp-style ssh unchanged", "git@github.com:foo/bar.git", "git@github.com:foo/bar.git"},
+		{"file url unchanged", "file:///tmp/origin.git", "file:///tmp/origin.git"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeOriginURL(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeOriginURL(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+			if strings.Contains(got, "ghp_") || strings.Contains(got, "pass") {
+				t.Errorf("sanitized URL still contains credential-like substring: %q", got)
+			}
+		})
+	}
+}
+
+func TestDropLocation_RedactsCredentialsInPrompt(t *testing.T) {
+	plan := persist.DropPlan{
+		Branch:    "_defrost",
+		OriginURL: "https://ghp_secrettoken@github.com/foo/bar.git",
+	}
+	got := dropLocation(plan)
+	if strings.Contains(got, "ghp_secrettoken") {
+		t.Errorf("dropLocation leaked token: %q", got)
+	}
+	if !strings.Contains(got, "github.com/foo/bar.git") {
+		t.Errorf("dropLocation lost the host/path: %q", got)
+	}
+}

--- a/exec.go
+++ b/exec.go
@@ -35,7 +35,6 @@ type ExecOpts struct {
 	RepoDir    string
 	DataBranch string
 	Persist    bool
-	NoRemote   bool
 	Dev        bool
 }
 
@@ -81,7 +80,6 @@ func execWith(a runner.Adapter, cmd []string, opts ExecOpts) int {
 		RepoDir:    opts.RepoDir,
 		DataBranch: opts.DataBranch,
 		AuthToken:  os.Getenv("GITHUB_TOKEN"),
-		NoRemote:   opts.NoRemote,
 		Dev:        opts.Dev,
 	}
 
@@ -305,7 +303,7 @@ func persistRun(pOpts persist.Options, run models.RunContext, results []models.T
 
 	if err := persist.New(pOpts).InsertNewRun(traces, wrappedMetrics); err != nil {
 		if errors.Is(err, persist.ErrNoOrigin) {
-			return errors.New("no 'origin' remote configured. Either add one (`git remote add origin ...`) or pass --no-remote to persist locally only")
+			return errors.New("no 'origin' remote configured. Either add one (`git remote add origin ...`) or pass --dev to write to a local scratch dir")
 		}
 		return err
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -278,10 +278,9 @@ func TestExecPlumbsAdapterMetricsToPersistence(t *testing.T) {
 	a := stubAdapter{results: results, metrics: metrics, code: 0}
 
 	code := execWith(a, []string{"stub"}, ExecOpts{
-		RepoDir:  repo,
-		Persist:  true,
-		NoRemote: true,
-		Dev:      true,
+		RepoDir: repo,
+		Persist: true,
+		Dev:     true,
 	})
 	if code != 0 {
 		t.Fatalf("expected exit 0, got %d", code)

--- a/history.go
+++ b/history.go
@@ -13,16 +13,16 @@ import (
 // historyMarshal emits one ResourceSpans per line as canonical OTLP/JSON.
 var historyMarshal = protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: false}
 
-func HandleHistory(testName, repoDir, dataBranch string, noRemote bool) int {
+func HandleHistory(testName, repoDir, dataBranch string, dev bool) int {
 	traces, err := persist.New(persist.Options{
 		RepoDir:    repoDir,
 		DataBranch: dataBranch,
 		AuthToken:  os.Getenv("GITHUB_TOKEN"),
-		NoRemote:   noRemote,
+		Dev:        dev,
 	}).GetTestHistory(testName)
 	if err != nil {
 		if errors.Is(err, persist.ErrNoOrigin) {
-			fmt.Fprintln(os.Stderr, "history: no 'origin' remote configured. Either add one (`git remote add origin ...`) or pass --no-remote to read from the local repo.")
+			fmt.Fprintln(os.Stderr, "history: no 'origin' remote configured. Either add one (`git remote add origin ...`) or pass --dev to read from the local scratch dir.")
 			return 1
 		}
 		fmt.Fprintln(os.Stderr, "history:", err)

--- a/internal/persist/drop.go
+++ b/internal/persist/drop.go
@@ -1,0 +1,270 @@
+package persist
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DropSelector chooses which signal directories to drop. At least one
+// flag must be true; both true means "drop everything".
+type DropSelector struct {
+	DropTraces  bool
+	DropMetrics bool
+}
+
+// DropPlan is the inventory shown to the user before a drop is executed.
+// All counts and bytes are computed from the data branch (or scratch dir)
+// as it currently exists; the date range is derived from the YYYY/MM/DD
+// path partitioning under traces/ and metrics/.
+type DropPlan struct {
+	Branch        string
+	OriginURL     string // empty in dev mode
+	Dev           bool
+	TraceFiles    int
+	MetricFiles   int
+	TraceBytes    int64
+	MetricBytes   int64
+	OldestRunUTC  time.Time
+	NewestRunUTC  time.Time
+	SuppressionsN int
+	BranchMissing bool // true when origin has no data branch yet
+	Sel           DropSelector
+}
+
+// Nothing reports whether the plan describes a no-op: either the branch
+// is missing, or the chosen selectors match zero files.
+func (p DropPlan) Nothing() bool {
+	if p.BranchMissing {
+		return true
+	}
+	if p.Sel.DropTraces && p.TraceFiles > 0 {
+		return false
+	}
+	if p.Sel.DropMetrics && p.MetricFiles > 0 {
+		return false
+	}
+	return true
+}
+
+// DropHistory inventories the data branch (or dev scratch dir) and, if
+// confirm returns true, rewrites it. For the git backend the rewrite is
+// a single orphan commit force-pushed with --force-with-lease against the
+// tip we cloned, so a concurrent writer can't be silently clobbered. For
+// the dev backend the chosen signal directories are simply deleted.
+//
+// confirm is called exactly once after the inventory is built. Returning
+// false aborts cleanly with no modifications. confirm is also called when
+// the plan is a no-op so the CLI can print "nothing to drop" with the
+// same context (branch / scratch dir).
+func (b *gitBackend) DropHistory(sel DropSelector, confirm func(DropPlan) bool) error {
+	if !sel.DropTraces && !sel.DropMetrics {
+		return errors.New("drop: nothing selected (need DropTraces and/or DropMetrics)")
+	}
+
+	branch := b.dataBranch()
+	remoteURL, err := resolveTargetURL(b.opts)
+	if err != nil {
+		return err
+	}
+
+	exists, err := branchExistsOnRemote(remoteURL, branch)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		plan := DropPlan{Branch: branch, OriginURL: remoteURL, BranchMissing: true, Sel: sel}
+		if confirm != nil {
+			confirm(plan)
+		}
+		return nil
+	}
+
+	workDir, err := os.MkdirTemp("", "defrost-drop-")
+	if err != nil {
+		return fmt.Errorf("mktemp: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+	_ = os.Remove(workDir) // git clone wants the path absent
+
+	if _, err := runGit("", "clone", "--quiet", "--depth=1", "--single-branch", "--branch", branch, remoteURL, workDir); err != nil {
+		return fmt.Errorf("clone data branch: %w", err)
+	}
+	clonedTip, err := runGit(workDir, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("rev-parse HEAD: %w", err)
+	}
+
+	plan := buildDropPlan(workDir, sel)
+	plan.Branch = branch
+	plan.OriginURL = remoteURL
+
+	if plan.Nothing() {
+		if confirm != nil {
+			confirm(plan)
+		}
+		return nil
+	}
+	if confirm != nil && !confirm(plan) {
+		return nil
+	}
+
+	if err := configureBotIdentity(workDir); err != nil {
+		return err
+	}
+	if sel.DropTraces {
+		if err := os.RemoveAll(filepath.Join(workDir, "traces")); err != nil {
+			return fmt.Errorf("remove traces: %w", err)
+		}
+	}
+	if sel.DropMetrics {
+		if err := os.RemoveAll(filepath.Join(workDir, "metrics")); err != nil {
+			return fmt.Errorf("remove metrics: %w", err)
+		}
+	}
+
+	// Build a single orphan commit on a fresh branch, then force-push it
+	// onto <branch> with a lease against the SHA we cloned. The lease
+	// makes a concurrent writer's push between our clone and our push
+	// fail loudly here instead of silently destroying their run.
+	const tmpBranch = "defrost-drop-tmp"
+	if _, err := runGit(workDir, "checkout", "--orphan", tmpBranch); err != nil {
+		return fmt.Errorf("checkout orphan: %w", err)
+	}
+	if _, err := runGit(workDir, "add", "-A", "."); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+	if _, err := runGit(workDir, "commit", "--quiet", "-m", dropCommitMessage(sel)); err != nil {
+		return fmt.Errorf("git commit: %w", err)
+	}
+
+	// No leading '+' on the refspec: '+' (and bare --force) bypass
+	// --force-with-lease, which would defeat the whole point of capturing
+	// the cloned tip. The lease alone provides the force-when-safe gate.
+	refspec := fmt.Sprintf("refs/heads/%s:refs/heads/%s", tmpBranch, branch)
+	leasespec := fmt.Sprintf("refs/heads/%s:%s", branch, clonedTip)
+	if _, err := runGit(workDir, "push", "--quiet", "--force-with-lease="+leasespec, "origin", refspec); err != nil {
+		return fmt.Errorf("force-push: %w", err)
+	}
+	return nil
+}
+
+func (b *fileBackend) DropHistory(sel DropSelector, confirm func(DropPlan) bool) error {
+	if !sel.DropTraces && !sel.DropMetrics {
+		return errors.New("drop: nothing selected (need DropTraces and/or DropMetrics)")
+	}
+
+	plan := buildDropPlan(b.dir, sel)
+	plan.Dev = true
+	if plan.Nothing() {
+		if confirm != nil {
+			confirm(plan)
+		}
+		return nil
+	}
+	if confirm != nil && !confirm(plan) {
+		return nil
+	}
+
+	if sel.DropTraces {
+		if err := os.RemoveAll(filepath.Join(b.dir, "traces")); err != nil {
+			return fmt.Errorf("remove traces: %w", err)
+		}
+	}
+	if sel.DropMetrics {
+		if err := os.RemoveAll(filepath.Join(b.dir, "metrics")); err != nil {
+			return fmt.Errorf("remove metrics: %w", err)
+		}
+	}
+	return nil
+}
+
+func buildDropPlan(dir string, sel DropSelector) DropPlan {
+	plan := DropPlan{Sel: sel}
+	plan.TraceFiles, plan.TraceBytes = inventorySignalDir(filepath.Join(dir, "traces"))
+	plan.MetricFiles, plan.MetricBytes = inventorySignalDir(filepath.Join(dir, "metrics"))
+	plan.OldestRunUTC, plan.NewestRunUTC = dateRangeFromPartitions(dir)
+	if ids, err := readSuppressionsFile(dir); err == nil {
+		plan.SuppressionsN = len(ids)
+	}
+	return plan
+}
+
+func inventorySignalDir(dir string) (int, int64) {
+	var n int
+	var bytes int64
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), fileSuffix) {
+			return nil
+		}
+		n++
+		if info, ierr := d.Info(); ierr == nil {
+			bytes += info.Size()
+		}
+		return nil
+	})
+	return n, bytes
+}
+
+func dateRangeFromPartitions(workDir string) (oldest, newest time.Time) {
+	for _, signal := range []string{"traces", "metrics"} {
+		root := filepath.Join(workDir, signal)
+		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d == nil {
+				return nil
+			}
+			if d.IsDir() || !strings.HasSuffix(d.Name(), fileSuffix) {
+				return nil
+			}
+			rel, rerr := filepath.Rel(root, path)
+			if rerr != nil {
+				return nil
+			}
+			parts := strings.Split(rel, string(filepath.Separator))
+			if len(parts) < 4 {
+				return nil
+			}
+			y, e1 := strconv.Atoi(parts[0])
+			m, e2 := strconv.Atoi(parts[1])
+			day, e3 := strconv.Atoi(parts[2])
+			if e1 != nil || e2 != nil || e3 != nil {
+				return nil
+			}
+			t := time.Date(y, time.Month(m), day, 0, 0, 0, 0, time.UTC)
+			if oldest.IsZero() || t.Before(oldest) {
+				oldest = t
+			}
+			if newest.IsZero() || t.After(newest) {
+				newest = t
+			}
+			return nil
+		})
+	}
+	return
+}
+
+func dropCommitMessage(sel DropSelector) string {
+	switch {
+	case sel.DropTraces && sel.DropMetrics:
+		return "defrost: drop history (traces + metrics)"
+	case sel.DropTraces:
+		return "defrost: drop history (traces)"
+	case sel.DropMetrics:
+		return "defrost: drop history (metrics)"
+	}
+	return "defrost: drop history"
+}

--- a/internal/persist/drop_test.go
+++ b/internal/persist/drop_test.go
@@ -1,0 +1,261 @@
+package persist
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func seedRun(t *testing.T, repoDir, runID, commit string) {
+	t.Helper()
+	run := newRunContext(runID, commit, "main")
+	traces := WrapSpansInResource(run.Resource, []*tracepb.Span{
+		NewRootSpan(run),
+		makeTestSpan(run, "p/TestA", tracepb.Status_STATUS_CODE_OK),
+	})
+	v := 1.0
+	metrics := []*metricspb.Metric{{
+		Name: "eval.score",
+		Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{
+			DataPoints: []*metricspb.NumberDataPoint{{
+				TimeUnixNano: uint64(run.StartTimeUnixNano) + 1,
+				Value:        &metricspb.NumberDataPoint_AsDouble{AsDouble: v},
+			}},
+		}},
+	}}
+	wrapped := WrapMetricsInResource(MetricResource(run), metrics)
+	if err := New(Options{RepoDir: repoDir}).InsertNewRun(traces, wrapped); err != nil {
+		t.Fatalf("seed run %s: %v", runID, err)
+	}
+}
+
+func confirmYes(_ DropPlan) bool { return true }
+func confirmNo(_ DropPlan) bool  { return false }
+
+func TestDropHistory_BothSignals_RewritesBranchAndPreservesSuppressions(t *testing.T) {
+	requireGit(t)
+	repoDir, originURL := makeFixture(t)
+	seedRun(t, repoDir, "run-1", "1111111111111111")
+	seedRun(t, repoDir, "run-2", "2222222222222222")
+
+	be := New(Options{RepoDir: repoDir})
+	addX := func(cur []string) []string { return append(cur, "p/TestX") }
+	if err := be.UpdateSuppressions(addX, "add X"); err != nil {
+		t.Fatalf("seed suppressions: %v", err)
+	}
+
+	var planSeen DropPlan
+	confirm := func(p DropPlan) bool { planSeen = p; return true }
+
+	if err := be.DropHistory(DropSelector{DropTraces: true, DropMetrics: true}, confirm); err != nil {
+		t.Fatalf("DropHistory: %v", err)
+	}
+
+	if planSeen.TraceFiles != 2 || planSeen.MetricFiles != 2 {
+		t.Errorf("plan inventory: traces=%d metrics=%d, want 2/2", planSeen.TraceFiles, planSeen.MetricFiles)
+	}
+	if planSeen.SuppressionsN != 1 {
+		t.Errorf("plan suppressions: %d want 1", planSeen.SuppressionsN)
+	}
+
+	verify := cloneDataBranch(t, originURL)
+	if entries := listFilesWithSuffix(t, filepath.Join(verify, "traces"), fileSuffix); len(entries) != 0 {
+		t.Errorf("traces should be gone, got %d files: %v", len(entries), entries)
+	}
+	if entries := listFilesWithSuffix(t, filepath.Join(verify, "metrics"), fileSuffix); len(entries) != 0 {
+		t.Errorf("metrics should be gone, got %d files: %v", len(entries), entries)
+	}
+	suppBytes, err := os.ReadFile(filepath.Join(verify, "suppressions.json"))
+	if err != nil {
+		t.Fatalf("read suppressions after drop: %v", err)
+	}
+	if !strings.Contains(string(suppBytes), "p/TestX") {
+		t.Errorf("suppressions not preserved across drop:\n%s", suppBytes)
+	}
+	if _, err := os.Stat(filepath.Join(verify, "README.md")); err != nil {
+		t.Errorf("README missing after drop: %v", err)
+	}
+
+	// History was rewritten — exactly one commit on the data branch.
+	out, err := exec.Command("git", "-C", verify, "rev-list", "--count", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-list: %v: %s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "1" {
+		t.Errorf("expected 1 commit on rewritten branch, got %s", got)
+	}
+}
+
+func TestDropHistory_TracesOnly_KeepsMetrics(t *testing.T) {
+	requireGit(t)
+	repoDir, originURL := makeFixture(t)
+	seedRun(t, repoDir, "run-1", "1111111111111111")
+
+	be := New(Options{RepoDir: repoDir})
+	if err := be.DropHistory(DropSelector{DropTraces: true}, confirmYes); err != nil {
+		t.Fatalf("DropHistory traces-only: %v", err)
+	}
+
+	verify := cloneDataBranch(t, originURL)
+	if entries := listFilesWithSuffix(t, filepath.Join(verify, "traces"), fileSuffix); len(entries) != 0 {
+		t.Errorf("traces should be gone, got %v", entries)
+	}
+	if entries := listFilesWithSuffix(t, filepath.Join(verify, "metrics"), fileSuffix); len(entries) != 1 {
+		t.Errorf("metrics should be preserved (1 file), got %d", len(entries))
+	}
+}
+
+func TestDropHistory_MetricsOnly_KeepsTraces(t *testing.T) {
+	requireGit(t)
+	repoDir, originURL := makeFixture(t)
+	seedRun(t, repoDir, "run-1", "1111111111111111")
+
+	be := New(Options{RepoDir: repoDir})
+	if err := be.DropHistory(DropSelector{DropMetrics: true}, confirmYes); err != nil {
+		t.Fatalf("DropHistory metrics-only: %v", err)
+	}
+
+	verify := cloneDataBranch(t, originURL)
+	if entries := listFilesWithSuffix(t, filepath.Join(verify, "metrics"), fileSuffix); len(entries) != 0 {
+		t.Errorf("metrics should be gone, got %v", entries)
+	}
+	if entries := listFilesWithSuffix(t, filepath.Join(verify, "traces"), fileSuffix); len(entries) != 1 {
+		t.Errorf("traces should be preserved (1 file), got %d", len(entries))
+	}
+}
+
+func TestDropHistory_ConfirmFalse_NoChanges(t *testing.T) {
+	requireGit(t)
+	repoDir, originURL := makeFixture(t)
+	seedRun(t, repoDir, "run-1", "1111111111111111")
+
+	be := New(Options{RepoDir: repoDir})
+	if err := be.DropHistory(DropSelector{DropTraces: true, DropMetrics: true}, confirmNo); err != nil {
+		t.Fatalf("DropHistory (rejected): %v", err)
+	}
+
+	verify := cloneDataBranch(t, originURL)
+	if entries := listFilesWithSuffix(t, filepath.Join(verify, "traces"), fileSuffix); len(entries) != 1 {
+		t.Errorf("rejected drop should not change traces, got %d files", len(entries))
+	}
+}
+
+func TestDropHistory_NoBranch_CallsConfirmAndReturnsNil(t *testing.T) {
+	requireGit(t)
+	repoDir, _ := makeFixture(t)
+
+	var planSeen DropPlan
+	confirm := func(p DropPlan) bool { planSeen = p; return true }
+
+	if err := New(Options{RepoDir: repoDir}).DropHistory(
+		DropSelector{DropTraces: true, DropMetrics: true}, confirm); err != nil {
+		t.Fatalf("DropHistory on missing branch: %v", err)
+	}
+	if !planSeen.BranchMissing {
+		t.Errorf("expected BranchMissing=true, got plan=%+v", planSeen)
+	}
+}
+
+func TestDropHistory_NothingSelected_Errors(t *testing.T) {
+	requireGit(t)
+	repoDir, _ := makeFixture(t)
+	err := New(Options{RepoDir: repoDir}).DropHistory(DropSelector{}, confirmYes)
+	if err == nil {
+		t.Errorf("expected error when no selectors set, got nil")
+	}
+}
+
+func TestDropHistory_LeaseAbortsOnConcurrentPush(t *testing.T) {
+	requireGit(t)
+	repoDir, originURL := makeFixture(t)
+	seedRun(t, repoDir, "run-1", "1111111111111111")
+
+	// Tee up: capture the cloned tip + working dir mid-flight by using
+	// confirm to land a competing commit on origin between our clone and
+	// our push. The lease must reject the push and the error must mention
+	// it (so the user knows to retry, not that there's a generic git
+	// failure).
+	be := New(Options{RepoDir: repoDir})
+	confirm := func(_ DropPlan) bool {
+		// Race a fresh run onto origin while the dropper holds its workdir.
+		seedRun(t, repoDir, "run-mid", "3333333333333333")
+		return true
+	}
+	err := be.DropHistory(DropSelector{DropTraces: true, DropMetrics: true}, confirm)
+	if err == nil {
+		t.Fatal("expected lease to reject push when origin advanced mid-drop")
+	}
+	if !strings.Contains(err.Error(), "force-push") && !strings.Contains(err.Error(), "stale") {
+		t.Errorf("expected force-push/lease error, got %v", err)
+	}
+
+	// And the racing run must still be there — i.e. we did NOT silently
+	// destroy it.
+	verify := cloneDataBranch(t, originURL)
+	traces := listFilesWithSuffix(t, filepath.Join(verify, "traces"), fileSuffix)
+	if len(traces) != 2 {
+		t.Errorf("racing run should be preserved on origin: want 2 trace files, got %d", len(traces))
+	}
+}
+
+func TestDropHistory_DevMode_RemovesSignalDirs(t *testing.T) {
+	requireGit(t)
+	repoDir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", repoDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	be := New(Options{RepoDir: repoDir, Dev: true})
+
+	run := newRunContext("dev-run", "abc", "main")
+	traces := WrapSpansInResource(run.Resource, []*tracepb.Span{NewRootSpan(run), makeTestSpan(run, "p/TestA", tracepb.Status_STATUS_CODE_OK)})
+	if err := be.InsertNewRun(traces, nil); err != nil {
+		t.Fatalf("seed dev run: %v", err)
+	}
+	if err := be.UpdateSuppressions(func(c []string) []string { return append(c, "S") }, "n/a"); err != nil {
+		t.Fatalf("seed dev suppression: %v", err)
+	}
+
+	scratch := filepath.Join(repoDir, DevDir)
+	if entries := listFilesWithSuffix(t, filepath.Join(scratch, "traces"), fileSuffix); len(entries) != 1 {
+		t.Fatalf("precondition: want 1 dev trace, got %d", len(entries))
+	}
+
+	if err := be.DropHistory(DropSelector{DropTraces: true, DropMetrics: true}, confirmYes); err != nil {
+		t.Fatalf("DropHistory dev: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(scratch, "traces")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected traces dir gone, stat err=%v", err)
+	}
+	// Suppressions preserved.
+	got, err := be.GetSuppressions()
+	if err != nil {
+		t.Fatalf("read suppressions: %v", err)
+	}
+	if len(got) != 1 || got[0] != "S" {
+		t.Errorf("suppressions not preserved: %v", got)
+	}
+}
+
+func TestDropHistory_DevMode_NothingToDrop_CallsConfirm(t *testing.T) {
+	requireGit(t)
+	repoDir := t.TempDir()
+	be := New(Options{RepoDir: repoDir, Dev: true})
+
+	var planSeen DropPlan
+	confirm := func(p DropPlan) bool { planSeen = p; return true }
+	if err := be.DropHistory(DropSelector{DropTraces: true, DropMetrics: true}, confirm); err != nil {
+		t.Fatalf("DropHistory: %v", err)
+	}
+	if !planSeen.Dev {
+		t.Errorf("plan.Dev should be true")
+	}
+	if !planSeen.Nothing() {
+		t.Errorf("plan should report Nothing()=true, got %+v", planSeen)
+	}
+}

--- a/internal/persist/persist.go
+++ b/internal/persist/persist.go
@@ -57,7 +57,6 @@ type Options struct {
 	RepoDir    string
 	DataBranch string // "" → DefaultDataBranch
 	AuthToken  string
-	NoRemote   bool
 	Dev        bool
 }
 
@@ -105,6 +104,11 @@ type Backend interface {
 	// per-run bundling under WrapMetricsInResource. Returns nil when
 	// there is no metrics data on disk.
 	LoadAllMetrics() ([]*metricspb.ResourceMetrics, error)
+
+	// DropHistory inventories the data branch and (after confirm returns
+	// true) rewrites it via a single orphan commit force-pushed with
+	// --force-with-lease. See drop.go for full semantics.
+	DropHistory(sel DropSelector, confirm func(DropPlan) bool) error
 }
 
 // New returns the Backend implied by opts. Dev mode selects the local
@@ -1107,9 +1111,6 @@ func runGit(dir string, args ...string) (string, error) {
 }
 
 func resolveTargetURL(opts Options) (string, error) {
-	if opts.NoRemote {
-		return localGitDir(opts.RepoDir)
-	}
 	return readOriginURL(opts.RepoDir)
 }
 
@@ -1126,17 +1127,6 @@ func readOriginURL(repoDir string) (string, error) {
 		return "", ErrNoOrigin
 	}
 	return out, nil
-}
-
-func localGitDir(repoDir string) (string, error) {
-	out, err := runGit(repoDir, "rev-parse", "--git-common-dir")
-	if err != nil {
-		return "", err
-	}
-	if !filepath.IsAbs(out) {
-		out = filepath.Join(repoDir, out)
-	}
-	return filepath.Abs(out)
 }
 
 func branchExistsOnRemote(remoteURL, branch string) (bool, error) {

--- a/internal/persist/persist_test.go
+++ b/internal/persist/persist_test.go
@@ -414,29 +414,6 @@ func TestPersist_RequiresOriginByDefault(t *testing.T) {
 	}
 }
 
-func TestPersist_LocalOnlyNoRemote(t *testing.T) {
-	requireGit(t)
-	dir := t.TempDir()
-	gitMust(t, "", "init", "-b", "main", dir)
-	gitMust(t, dir, "config", "user.email", "t@example.com")
-	gitMust(t, dir, "config", "user.name", "t")
-	gitMust(t, dir, "commit", "--allow-empty", "-m", "init")
-
-	run := newRunContext("local-run", "abc123", "main")
-	traces := WrapSpansInResource(run.Resource, []*tracepb.Span{NewRootSpan(run), makeTestSpan(run, "p/TestA", tracepb.Status_STATUS_CODE_OK)})
-	if err := New(Options{RepoDir: dir, NoRemote: true}).InsertNewRun(traces, nil); err != nil {
-		t.Fatalf("InsertNewRun (no-remote): %v", err)
-	}
-
-	got, err := New(Options{RepoDir: dir, NoRemote: true}).GetTestHistory("p/TestA")
-	if err != nil {
-		t.Fatalf("GetTestHistory: %v", err)
-	}
-	if len(got) != 1 {
-		t.Errorf("want 1 history row, got %d", len(got))
-	}
-}
-
 func TestPersist_DevModeWritesScratchDirAndSkipsGit(t *testing.T) {
 	requireGit(t)
 	dir := t.TempDir()

--- a/main.go
+++ b/main.go
@@ -18,38 +18,43 @@ func main() {
 			RepoDir:    CLI.Exec.RepoDir,
 			DataBranch: CLI.Exec.DataBranch,
 			Persist:    !CLI.Exec.NoPersist,
-			NoRemote:   CLI.Exec.NoRemote,
 			Dev:        CLI.Exec.Dev,
 		}))
 	case strings.HasPrefix(cmd, "history"):
-		os.Exit(HandleHistory(CLI.History.Test, CLI.History.RepoDir, CLI.History.DataBranch, CLI.History.NoRemote))
+		os.Exit(HandleHistory(CLI.History.Test, CLI.History.RepoDir, CLI.History.DataBranch, CLI.History.Dev))
 	case strings.HasPrefix(cmd, "suppress add"):
 		os.Exit(HandleSuppressAdd(CLI.Suppress.Add.Tests, SuppressOpts{
 			RepoDir:    CLI.Suppress.Add.RepoDir,
 			DataBranch: CLI.Suppress.Add.DataBranch,
-			NoRemote:   CLI.Suppress.Add.NoRemote,
 			Dev:        CLI.Suppress.Add.Dev,
 		}))
 	case strings.HasPrefix(cmd, "suppress remove"):
 		os.Exit(HandleSuppressRemove(CLI.Suppress.Remove.Test, SuppressOpts{
 			RepoDir:    CLI.Suppress.Remove.RepoDir,
 			DataBranch: CLI.Suppress.Remove.DataBranch,
-			NoRemote:   CLI.Suppress.Remove.NoRemote,
 			Dev:        CLI.Suppress.Remove.Dev,
 		}))
 	case strings.HasPrefix(cmd, "suppress list"):
 		os.Exit(HandleSuppressList(SuppressOpts{
 			RepoDir:    CLI.Suppress.List.RepoDir,
 			DataBranch: CLI.Suppress.List.DataBranch,
-			NoRemote:   CLI.Suppress.List.NoRemote,
 			Dev:        CLI.Suppress.List.Dev,
+		}))
+	case strings.HasPrefix(cmd, "drop history"):
+		os.Exit(HandleDropHistory(DropOpts{
+			RepoDir:     CLI.Drop.History.RepoDir,
+			DataBranch:  CLI.Drop.History.DataBranch,
+			TracesOnly:  CLI.Drop.History.TracesOnly,
+			MetricsOnly: CLI.Drop.History.MetricsOnly,
+			Yes:         CLI.Drop.History.Yes,
+			Dev:         CLI.Drop.History.Dev,
 		}))
 	case strings.HasPrefix(cmd, "serve"):
 		os.Exit(HandleServe(ServeOpts{
 			Port:       CLI.Serve.Port,
 			RepoDir:    CLI.Serve.RepoDir,
 			DataBranch: CLI.Serve.DataBranch,
-			NoRemote:   CLI.Serve.NoRemote,
+			Dev:        CLI.Serve.Dev,
 		}))
 	default:
 		fmt.Fprintln(os.Stderr, "unknown command:", cmd)

--- a/serve.go
+++ b/serve.go
@@ -17,7 +17,7 @@ type ServeOpts struct {
 	Port       int
 	RepoDir    string
 	DataBranch string
-	NoRemote   bool
+	Dev        bool
 }
 
 func HandleServe(opts ServeOpts) int {
@@ -25,7 +25,7 @@ func HandleServe(opts ServeOpts) int {
 		RepoDir:    opts.RepoDir,
 		DataBranch: opts.DataBranch,
 		AuthToken:  os.Getenv("GITHUB_TOKEN"),
-		NoRemote:   opts.NoRemote,
+		Dev:        opts.Dev,
 	}
 
 	addr := "127.0.0.1:" + strconv.Itoa(opts.Port)

--- a/suppress.go
+++ b/suppress.go
@@ -10,7 +10,6 @@ import (
 type SuppressOpts struct {
 	RepoDir    string
 	DataBranch string
-	NoRemote   bool
 	Dev        bool
 }
 
@@ -19,7 +18,6 @@ func (s SuppressOpts) toPersist() persist.Options {
 		RepoDir:    s.RepoDir,
 		DataBranch: s.DataBranch,
 		AuthToken:  os.Getenv("GITHUB_TOKEN"),
-		NoRemote:   s.NoRemote,
 		Dev:        s.Dev,
 	}
 }

--- a/suppress_test.go
+++ b/suppress_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestHandleSuppressAdd_Single(t *testing.T) {
 	repo := makeRepo(t)
-	opts := SuppressOpts{RepoDir: repo, NoRemote: true, Dev: true}
+	opts := SuppressOpts{RepoDir: repo, Dev: true}
 
 	code := HandleSuppressAdd([]string{"pkg/TestA"}, opts)
 	if code != 0 {
@@ -27,7 +27,7 @@ func TestHandleSuppressAdd_Single(t *testing.T) {
 
 func TestHandleSuppressAdd_MultipleIDs(t *testing.T) {
 	repo := makeRepo(t)
-	opts := SuppressOpts{RepoDir: repo, NoRemote: true, Dev: true}
+	opts := SuppressOpts{RepoDir: repo, Dev: true}
 
 	code := HandleSuppressAdd([]string{"a", "b", "c"}, opts)
 	if code != 0 {
@@ -46,7 +46,7 @@ func TestHandleSuppressAdd_MultipleIDs(t *testing.T) {
 
 func TestHandleSuppressAdd_EmptySliceFails(t *testing.T) {
 	repo := makeRepo(t)
-	opts := SuppressOpts{RepoDir: repo, NoRemote: true, Dev: true}
+	opts := SuppressOpts{RepoDir: repo, Dev: true}
 	code := HandleSuppressAdd(nil, opts)
 	if code != 2 {
 		t.Fatalf("expected 2, got %d", code)
@@ -55,7 +55,7 @@ func TestHandleSuppressAdd_EmptySliceFails(t *testing.T) {
 
 func TestHandleSuppressAdd_SkipsEmptyStrings(t *testing.T) {
 	repo := makeRepo(t)
-	opts := SuppressOpts{RepoDir: repo, NoRemote: true, Dev: true}
+	opts := SuppressOpts{RepoDir: repo, Dev: true}
 	code := HandleSuppressAdd([]string{"", "real-id", ""}, opts)
 	if code != 0 {
 		t.Fatalf("expected 0, got %d", code)
@@ -72,7 +72,7 @@ func TestHandleSuppressAdd_SkipsEmptyStrings(t *testing.T) {
 
 func TestHandleSuppressAdd_AllEmptyStringsFails(t *testing.T) {
 	repo := makeRepo(t)
-	opts := SuppressOpts{RepoDir: repo, NoRemote: true, Dev: true}
+	opts := SuppressOpts{RepoDir: repo, Dev: true}
 	code := HandleSuppressAdd([]string{"", ""}, opts)
 	if code != 2 {
 		t.Fatalf("expected 2, got %d", code)


### PR DESCRIPTION
## Summary

- New `defrost drop history` command rewrites the data branch via orphan commit + `--force-with-lease` push, so git can actually reclaim the space taken by old traces/metrics. Selectors: `--traces-only` / `--metrics-only` (default = both). Type-the-word `drop` confirmation prompt; `--yes` to skip for CI.
- Removed `--no-remote` from every command. It was redundant with `--dev` (file backend, scratch dir), which covers "don't push to origin" without a hidden git path. `gitBackend` is now remote-only. Added `--dev` to `defrost serve` so the dashboard can read the scratch dir.

## Why

The data branch grows monotonically (one trace + one metrics file per `defrost exec`). A normal `git rm` commit doesn't shrink anything because old blobs stay reachable from prior commits. The orphan-commit rewrite makes them unreachable so the remote can GC them.

`--no-remote` (push the data branch to the local repo's `.git` instead of origin) was a niche escape hatch that overlapped almost completely with `--dev`. Killing it removes a code path and a config matrix from every command.

## Reviewer notes

- **Lease, not force.** `git push --force-with-lease=refs/heads/_defrost:<cloned-tip>` aborts cleanly if a concurrent `defrost exec` pushes between the confirmation and the rewrite. **Important detail in [drop.go](internal/persist/drop.go):** the refspec deliberately has no leading `+` — both `+` and bare `--force` *bypass* `--force-with-lease`. Test `TestDropHistory_LeaseAbortsOnConcurrentPush` exercises the race and verifies the racing run survives on origin.
- **Suppressions preserved.** The orphan commit re-adds `suppressions.json` and the seed `README.md`, plus whichever signal directory was kept under partial drops.
- **Test migration.** `--no-remote` tests already used `makeFixture` (bare repo via `origin`), so most just dropped the flag. `TestPersist_LocalOnlyNoRemote` was deleted (its purpose vanishes).
- **README** got a thorough `drop history` section with sample prompt output, edge cases (empty, missing branch, race), and a `--dev` example.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (the deliberate-flaky `TestSeventyPercentPass` aside)
- [x] New tests in `internal/persist/drop_test.go`: both signals, `--traces-only`, `--metrics-only`, confirm=false, missing branch, no selectors, lease aborts under race, dev mode, dev nothing-to-drop
- [x] `go run . drop history --help` matches the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)