### PR TITLE
fix(serve): check err before using resp in drop_test

### DIFF
--- a/internal/serve/drop_test.go
+++ b/internal/serve/drop_test.go
@@ -125,7 +125,10 @@ func TestDropPlan_SanitizesOriginURL(t *testing.T) {
 	})
 	defer srv.Close()
 
-	resp, _ := http.Get(srv.URL + "/api/drop/plan?drop_traces=true&drop_metrics=true")
+	resp, err := http.Get(srv.URL + "/api/drop/plan?drop_traces=true&drop_metrics=true")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
 	defer resp.Body.Close()
 	var body dropPlanResponse
 	_ = json.NewDecoder(resp.Body).Decode(&body)
@@ -234,7 +237,10 @@ func TestDrop_NoOpPlanReturnsNothingTrue(t *testing.T) {
 	defer srv.Close()
 
 	body := bytes.NewBufferString(`{"drop_traces":true,"drop_metrics":true}`)
-	resp, _ := http.Post(srv.URL+"/api/drop", "application/json", body)
+	resp, err := http.Post(srv.URL+"/api/drop", "application/json", body)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
 	defer resp.Body.Close()
 	var got dropPlanResponse
 	_ = json.NewDecoder(resp.Body).Decode(&got)


### PR DESCRIPTION
## Summary

Two `go vet` errors on `main` HEAD:

```
internal/serve/drop_test.go:129:8: using resp before checking for errors
internal/serve/drop_test.go:238:8: using resp before checking for errors
```

Both call sites read fields from `resp` (specifically `resp.Body.Close` via `defer`) before checking the returned `err` from the HTTP call. On a network error this would nil-deref instead of failing cleanly. Fixed by checking `err` first and `t.Fatalf`-ing if non-nil, matching the pattern already used elsewhere in the file.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./internal/serve/...` — passes

https://claude.ai/code/session_01KW6cqcXmQRCsvMciF8jxwr

---
_Generated by [Claude Code](https://claude.ai/code/session_01KW6cqcXmQRCsvMciF8jxwr)_