### PR TITLE
docs: LangSmith/Langfuse competitive roadmap + 10 build specs

### DIFF
--- a/docs/_internal/specs/2026-05-05-annotations-feedback.md
+++ b/docs/_internal/specs/2026-05-05-annotations-feedback.md
@@ -1,0 +1,179 @@
+# Spec #8 — Annotations & feedback
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation. Depends on [`#1 trace-tree-ui`](./2026-05-05-trace-tree-ui.md).
+**Phase:** 5 — feedback + observability polish.
+
+## 1. Goal
+
+Human-in-the-loop scoring and feedback on captured runs. A reviewer can score a trace (or a specific span), leave a label and free-text comment, and have it persist on the data branch. An "annotation queue" view lists unscored runs ordered by need-review-most.
+
+A reviewer can:
+
+1. Click a span / trace, open an annotation panel, score and comment in one action.
+2. See all prior annotations on the same span.
+3. Open `/queue` to triage a backlog of unscored runs.
+
+## 2. Why this matters competitively
+
+Both LangSmith and Langfuse ship "annotation queues" and "user feedback" as explicit features. LangSmith's pricing model penalizes feedback (it auto-upgrades traces to a more expensive tier — see parent spec). defrost has no such penalty: annotations are JSON files on the data branch, free to add, free to query, and `git diff`-able like everything else.
+
+This is also the natural pair with spec [`#3 datasets`](./2026-05-05-datasets.md): unscored rows captured from production become the queue. Scoring them turns the queue into a labeled dataset — closing the human-feedback loop.
+
+## 3. Public docs to write first
+
+- **New page:** `docs/guides/reviewing-runs.md` — "Score traces and build a labeled dataset." Sections: "Open a trace", "Annotate a span", "Use the annotation queue", "From annotations to datasets".
+- **New page:** `docs/reference/cli/annotate.md` — full CLI reference.
+- **New concept page:** `docs/concepts/annotations.md` — the relationship between annotations, feedback, datasets, and judges.
+- **Edit:** `docs/reference/storage-layout.md` — add `feedback/` to the directory tree.
+- **Edit:** `docs/reference/serve-api.md` — document new endpoints.
+
+## 4. Storage layout
+
+On the data branch:
+
+```text
+<repo>/.defrost/feedback/
+└── <trace-id>.jsonl       # append-only feedback events for this trace
+```
+
+Each line is one feedback event:
+
+```json
+{
+  "id": "<uuid>",
+  "trace_id": "<hex>",
+  "span_id": "<hex|null>",
+  "score": 0.7,
+  "label": "off-topic",
+  "comment": "The reply ignored the user's specific question.",
+  "by": "alice@example.com",
+  "at": "2026-05-05T12:00:00Z",
+  "kind": "human"
+}
+```
+
+- `score` is a float `[0, 1]`. Empty if the reviewer chose label-only.
+- `label` is a string. Free-form in v1; a future spec can add per-project label vocabularies.
+- `kind` is `"human"` for manual annotations, `"feedback"` for end-user thumbs-up/down (reserved for future), `"judge"` is **NOT** used here — judge scores live on the trace span itself per spec #4.
+- Append-only. Editing an annotation is a new event with `id` referencing the prior. Deleting is a new event with `kind = "retract"` referencing the prior — never erasing the line. (`git revert` on the file is the escape hatch for true mistakes.)
+
+`<trace-id>.jsonl` files are written atomically (write `.tmp`, fsync, rename, fsync parent — same pattern as trace files).
+
+## 5. CLI surface
+
+`defrost annotate` parent command. Subcommands:
+
+### `defrost annotate <trace-id> [--span <span-id>] --score <0-1> [--label <s>] [--comment <s>]`
+
+Append a feedback event. Reviewer identity defaults to `git config user.email` (with a fallback to `$USER@<hostname>`). Override with `--by <email>`.
+
+### `defrost feedback list [--trace <id>] [--by <email>] [--label <s>] [--json]`
+
+Print feedback events. Default: NDJSON to stdout. Filters compose with AND.
+
+### `defrost feedback queue [--limit <N>] [--unscored-only] [--json]`
+
+Print runs that need review. Sorted by oldest-first within the cap. `--unscored-only` excludes traces with any human feedback.
+
+## 6. HTTP API surface
+
+In `internal/serve/feedback.go`:
+
+| Method + path | Returns |
+|---|---|
+| `POST /api/trace/{trace-id}/feedback` | Body: `{span_id?, score?, label?, comment?}`. Appends an event. Reviewer identity from request body or session-set "Reviewer" header. Returns 201 + the new event. |
+| `GET /api/trace/{trace-id}/feedback` | `{events: [...]}` — all feedback events for this trace. |
+| `GET /api/feedback?trace_id=&by=&label=` | Filtered feed. |
+| `GET /api/feedback/queue?limit=50&unscored_only=true` | Returns runs ordered by triage priority. |
+| `DELETE /api/trace/{trace-id}/feedback/{event-id}` | Appends a `kind=retract` event referencing `<event-id>`. Returns 200 + the retract event. Does NOT delete the original line — uses the retract pattern. |
+
+Cache-Control:
+
+- `GET /api/trace/{trace-id}/feedback` → `public, max-age=10` (mutable on annotation).
+- `GET /api/feedback/queue` → `public, max-age=10`.
+- POSTs / DELETEs → no cache.
+
+## 7. Web UI surface
+
+| File | Role |
+|---|---|
+| `web/src/components/AnnotationPanel.tsx` (new) | Right-side panel attached to `SpanDetail` (spec #1). Shows existing annotations + an inline "Add annotation" form (score slider, label input, comment textarea). |
+| `web/src/components/FeedbackChip.tsx` (new) | Small chip on a span row (in `TraceTree`) when one or more feedback events exist. Hover: see latest. |
+| `web/src/pages/Queue.tsx` (new) | `/queue`. Table of unscored runs with quick-score buttons. Keyboard-driven (j/k to move, 0–9 to score, l for label, c for comment). |
+| `web/src/components/ReviewerIdentity.tsx` (new) | Top-nav widget. On first use, prompts the reviewer for an email; persists to localStorage; sends as `Reviewer` header on every request from then on. |
+
+App.tsx route: `/queue`.
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/persist/persist.go` | Same clone-mutate-push pattern. Add `AppendFeedback(traceID string, event FeedbackEvent, msg string) error`. |
+| `internal/serve/server.go` | Wire endpoints; impl in `internal/serve/feedback.go`. |
+| `internal/cli/cli.go`, `wire.go` | Add `Annotate` and `Feedback` commands. |
+| `web/src/components/SpanDetail.tsx` (spec #1) | Mount `AnnotationPanel`. |
+| `web/src/components/TraceTree.tsx` (spec #1) | Render `FeedbackChip` on annotated spans. |
+| `web/src/components/AddToDatasetButton.tsx` (spec #3) | Reuse pattern for the queue's "promote to dataset" button. |
+
+**New files only:**
+
+- `internal/feedback/` — `event.go`, `event_test.go`, `queue.go`, `queue_test.go`. Pure logic.
+- `internal/persist/feedback.go` (+ test)
+- `internal/serve/feedback.go` (+ test)
+- `internal/cli/annotate.go` (+ test); `internal/cli/feedback.go` (+ test)
+- `web/src/components/AnnotationPanel.tsx`, `FeedbackChip.tsx`, `ReviewerIdentity.tsx` plus tests.
+- `web/src/pages/Queue.tsx` (+ test)
+- Public docs as listed in §3.
+
+## 9. OTel emission
+
+`POST /api/trace/{trace-id}/feedback` emits one span:
+
+```text
+span.name       = "defrost.feedback.append"
+span.attributes = {
+  "defrost.feedback.trace_id":  <hex>,
+  "defrost.feedback.event_id":  <uuid>,
+  "defrost.feedback.kind":      "human",
+  "defrost.feedback.has_score": <bool>,
+  "defrost.feedback.has_label": <bool>,
+  "defrost.feedback.by":        <reviewer email>,
+}
+```
+
+This makes annotation activity itself observable. Useful for tracking reviewer throughput.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/feedback/event_test.go` | JSON round-trip; UUID generation; retract pattern preserves history. |
+| `internal/feedback/queue_test.go` | Queue ordering: oldest-first, unscored-only filter, `limit` honored. |
+| `internal/persist/feedback_test.go` | Append produces a new commit; concurrent appends to the same file converge under retry. |
+| `internal/serve/feedback_test.go` | All endpoints. POST with malformed body → 400 with clear error. DELETE produces a retract event, not a line removal. |
+| `internal/cli/annotate_test.go` | `defrost annotate <trace-id> --score 0.5 --comment "..."` end-to-end. |
+| `web/src/components/AnnotationPanel.test.tsx`, `FeedbackChip.test.tsx`, `ReviewerIdentity.test.tsx` | Render + form submission flows. |
+| `web/src/pages/Queue.test.tsx` | Keyboard navigation. Quick-score writes via POST and updates the row. |
+
+## 11. Acceptance criteria
+
+- A reviewer can score a trace or a span from the dashboard, with the result persisting on the data branch.
+- Existing annotations show in `AnnotationPanel` ordered newest-first.
+- A `FeedbackChip` appears on annotated span rows in the trace tree.
+- `/queue` shows unscored runs and supports keyboard-driven triage.
+- `defrost annotate` from the CLI produces the same on-disk event as the dashboard would.
+- Retract is a new event, never a line deletion. Original annotations remain in git history.
+- `git diff main..feature -- .defrost/feedback/` shows annotation evolution per PR.
+- Public docs at `docs/guides/reviewing-runs.md`, `docs/concepts/annotations.md`, `docs/reference/cli/annotate.md` exist.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+- **Reviewer identity in OSS self-host.** Recommendation: read `git config user.email` for CLI; for the dashboard, `ReviewerIdentity.tsx` prompts on first use and persists to localStorage. Document explicitly that this is honor-system in the OSS tier; auth is hosted-tier territory.
+- **Per-project label vocabularies.** Out of scope for v1. Add later if free-text labels prove unwieldy.
+- **End-user "thumbs up/down" feedback.** Important for production apps but requires a programmatic POST endpoint with rate limiting and probably auth. Defer; spec separately when demand surfaces.
+- **Retract vs delete.** Recommendation: retract pattern as specified. Annotation provenance matters for audit and for ML training data quality. Don't allow erasure.
+- **Promote queue items to datasets.** Mentioned as a button in §7 (`AddToDatasetButton`). Recommendation: ship in v1 — it's the workflow-completing affordance.
+- **Pairwise human eval.** "Which output is better, A or B?" UI. Recommendation: defer — implementable atop `/compare` (spec #5) + this spec's POST endpoint, but the UI is its own design problem.

--- a/docs/_internal/specs/2026-05-05-cost-token-surfacing.md
+++ b/docs/_internal/specs/2026-05-05-cost-token-surfacing.md
@@ -1,0 +1,194 @@
+# Spec #2 — Cost & token surfacing
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation. Hangs off spec [`#1 trace-tree-ui`](./2026-05-05-trace-tree-ui.md).
+**Phase:** 1 — close the trace UX gap.
+
+## 1. Goal
+
+Surface the OTel `gen_ai.usage.*` and `gen_ai.response.*` data already captured in existing traces. Every span row in the trace tree shows tokens-in / tokens-out / cost. The home page gains a daily-cost chart spanning the last 30 days. No on-disk schema change — this is pure read-side surfacing of data we already collect.
+
+## 2. Why this matters competitively
+
+LangSmith's marketing leans hard on "we automatically capture token counts and calculate cost." So does Langfuse's. Without a cost column on the trace view, users assume defrost doesn't track it — even though we do, in standard `gen_ai.usage.*` attributes. This spec closes the perception gap with one PR's worth of UI work.
+
+It also opens the door to cost regression detection in CI, which becomes a defrost-only feature once history-travels-with-code combines with cost-per-trace data: `git diff main..feature` can flag PRs that increase cost.
+
+## 3. Public docs to write first
+
+- **New page:** `docs/guides/tracking-llm-cost.md` — a 1-screen guide. Sections: "How costs are computed (from `gen_ai.*` attributes)", "Configuring the price map", "Reading cost in the dashboard", "Cost regressions in PRs". Stay neutral.
+- **Edit:** `docs/reference/otel-ingestion.md` — add a section listing the `gen_ai.*` attributes we read and what each one is used for. Cite the OTel semantic conventions URL.
+- **Edit:** `docs/reference/serve-api.md` — document the new `/api/cost/summary` endpoint from §6.
+- **Edit:** `docs/guides/inspecting-a-trace.md` (created in spec #1) — add a paragraph on the cost/token columns.
+
+## 4. Storage layout
+
+**No change.** Cost and token data is already in the OTLP traces under span attributes. The DuckDB cache already projects span attributes; this spec adds a query pattern, not a schema change.
+
+A new file ships in the binary, **not** on the data branch:
+
+- `internal/cost/prices.go` — a static price map keyed by model name. Compiled in. Users override via a config file (see §5 / §12).
+
+## 5. CLI surface
+
+One new command:
+
+- `defrost cost summary [--from <date>] [--to <date>] [--by <model|run|day>] [--json]` — print cost rollup. Defaults: last 30 days, grouped by day, human-readable.
+
+Flag for overriding the bundled price map:
+
+- Existing `defrost serve` and `defrost exec` both gain `--prices <path>` (a JSON or YAML file). Default: bundled. The flag lives in `internal/cli/runtime.go` so both commands pick it up uniformly.
+
+Price file format:
+
+```yaml
+# prices.yaml — overrides the bundled price map
+"openai/gpt-5":
+  input_per_mtok: 5.00
+  output_per_mtok: 15.00
+"anthropic/claude-opus-4-7":
+  input_per_mtok: 15.00
+  output_per_mtok: 75.00
+```
+
+Bundled defaults live in `internal/cost/prices.go` as a Go map literal. Bump them when models ship; treat as a regular code change.
+
+## 6. HTTP API surface
+
+### Extend `GET /api/trace/{trace-id}/tree` (from spec #1)
+
+Each span in the response gains three optional fields:
+
+```json
+{
+  "tokens_in": 1234,
+  "tokens_out": 567,
+  "cost_usd": 0.018
+}
+```
+
+If any of the three can't be computed (no `gen_ai.usage.*` attrs, no model match in the price map), omit it from the JSON. The dashboard shows `—`.
+
+### New: `GET /api/cost/summary`
+
+```
+GET /api/cost/summary?from=<RFC3339>&to=<RFC3339>&by=<day|run|model>
+```
+
+Returns:
+
+```json
+{
+  "from": "2026-04-05T00:00:00Z",
+  "to":   "2026-05-05T00:00:00Z",
+  "buckets": [
+    { "key": "2026-04-30", "cost_usd": 12.34, "tokens_in": 1234567, "tokens_out": 345678 }
+  ],
+  "total": { "cost_usd": 234.56, "tokens_in": ..., "tokens_out": ... },
+  "estimated": true
+}
+```
+
+`estimated: true` whenever any contributing span had no provider-emitted `gen_ai.usage.cost` attr and we computed cost from the price map. The dashboard renders an "estimate" badge when this is set.
+
+**Cache-Control:** `public, max-age=60` (matches `/api/tests`).
+
+### Querier extension
+
+```go
+type QuerierWithCost interface {
+    Querier
+    CostByDay(from, to time.Time) ([]CostBucket, error)
+    CostByRun(from, to time.Time) ([]CostBucket, error)
+    CostByModel(from, to time.Time) ([]CostBucket, error)
+}
+
+type CostBucket struct {
+    Key        string  // date-stamp / run-id / model name depending on grouping
+    CostUSD    float64
+    TokensIn   int64
+    TokensOut  int64
+    Estimated  bool
+}
+```
+
+Implement in `internal/query/duckdb/cost.go`. Reuse the existing span scan; aggregate via DuckDB SQL.
+
+## 7. Web UI surface
+
+- **`web/src/components/TraceTree.tsx` (from spec #1):** add three columns on each span row — `Tokens in`, `Tokens out`, `Cost`. Right-aligned, monospace. Empty cell if not applicable.
+- **`web/src/components/SpanDetail.tsx` (from spec #1):** add a "Cost" mini-section above the attributes table when cost data is present. Shows breakdown: tokens, model, computed-vs-emitted source, $ amount.
+- **`web/src/components/CostChart.tsx` (new):** a recharts `LineChart` of daily cost across the last 30 days. Hover tooltip shows day + cost + token breakdown. "Estimate" badge if any bucket is estimated.
+- **`web/src/pages/Home.tsx` (or wherever the heatmap lives — see App.tsx):** add `<CostChart />` above the heatmap.
+- **Existing `RunCell` / `RunDetailSheet`:** add a small `$N.NN` cost badge per run cell when cost data exists. Keep it subtle so the green/red status stays the dominant signal.
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/query/duckdb/` | Add `cost.go` next to existing query files. Reuse the span row table and attribute JSON projection. |
+| `internal/serve/server.go` | Extend the `/api/trace/.../tree` handler to enrich span DTOs with cost fields. Add `/api/cost/summary` handler in a new `internal/serve/cost.go`. |
+| `internal/cli/runtime.go` | Existing flag-merging point for `defrost exec` / `defrost serve`. Add `--prices`. |
+| `internal/cli/cli.go` | Add the `Cost` subcommand struct (kong) following the existing `Suppress` / `Drop` patterns. |
+| `web/src/components/TraceTree.tsx`, `SpanDetail.tsx` | Created in spec #1; extend in this spec. |
+| Existing `web/src/components/` chart code (e.g., `DurationSparkline.tsx`) | Reuse the recharts + shadcn chart wrapper pattern for `CostChart`. |
+| `docs/concepts/otel-as-ingestion.md` | Cite — explains why OTel attributes are the source of truth. |
+
+**New files only:**
+
+- `internal/cost/prices.go` (+ `prices_test.go`)
+- `internal/cost/compute.go` — `func ComputeCost(model string, in, out int64) (float64, bool /*estimated*/)`. Pure function; no I/O.
+- `internal/serve/cost.go` (+ `cost_test.go`)
+- `internal/query/duckdb/cost.go` (+ `cost_test.go`)
+- `internal/cli/cost.go` (+ `cost_test.go`) — wires the new `defrost cost summary` command.
+- `web/src/components/CostChart.tsx` (+ `CostChart.test.tsx`)
+- `docs/guides/tracking-llm-cost.md`
+
+## 9. OTel emission
+
+This feature **consumes** OTel attributes, doesn't emit them. We read:
+
+| Attribute | Used for |
+|---|---|
+| `gen_ai.usage.input_tokens` | Tokens-in column |
+| `gen_ai.usage.output_tokens` | Tokens-out column |
+| `gen_ai.usage.total_tokens` | Fallback if `input` / `output` are absent (split via 50/50 if unknown — flag as estimate) |
+| `gen_ai.response.model` | Price-map lookup key |
+| `gen_ai.request.model` | Fallback when response.model is absent |
+| `gen_ai.usage.cost` | If present, use directly; mark `estimated: false` |
+
+Reference: [OpenTelemetry Semantic Conventions for Generative AI](https://opentelemetry.io/docs/specs/semconv/gen-ai/) — link from the new doc page.
+
+If a span has none of these, it's not an LLM call (could be a tool, a retrieval step, etc.) — show empty cells, not `0`.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/cost/compute_test.go` | Pure-function unit tests for the price-map lookup. Covers: known model, unknown model (returns `(0, false, ErrUnknownModel)` or similar — pick a sentinel), zero tokens, large counts, custom override file. |
+| `internal/cost/prices_test.go` | Bundled price map parses cleanly. Loading a YAML override merges correctly (override wins). |
+| `internal/query/duckdb/cost_test.go` | Given a fixture trace with three LLM spans (mixed providers, mixed token counts), `CostByDay` / `CostByRun` / `CostByModel` produce the expected aggregates. `Estimated` is true iff at least one span used the price map. |
+| `internal/serve/cost_test.go` | `/api/cost/summary?from&to&by=day` returns the expected JSON shape and 200 + `Cache-Control: public, max-age=60`. Invalid `from`/`to` → 400 with a clear error. |
+| `internal/serve/trace_test.go` (extended from spec #1) | `/api/trace/.../tree` includes `tokens_in`, `tokens_out`, `cost_usd` on LLM spans and omits them on non-LLM spans. |
+| `web/src/components/CostChart.test.tsx` | Renders given a 30-day sample; hover tooltip shape correct; "Estimate" badge appears when any bucket is estimated. |
+| `web/src/components/TraceTree.test.tsx` (extended from spec #1) | Token / cost columns render with values and with `—` for non-LLM spans. |
+
+## 11. Acceptance criteria
+
+- Every trace tree row that represents an LLM call shows `tokens_in`, `tokens_out`, and `$ cost`. Rows for non-LLM spans show `—` (empty cell, not zero).
+- The home page shows a daily-cost line chart for the last 30 days. Hover reveals the per-day breakdown.
+- An "Estimate" badge appears anywhere a cost was computed from the price map rather than emitted by the producer.
+- Unknown models render `—` with a console warning (no error toast). The user can pass `--prices` to override.
+- `defrost cost summary` prints a human-readable rollup. `--json` prints JSON identical to `/api/cost/summary`.
+- The bundled price map covers, at minimum, today's defaults: gpt-5, gpt-5-mini, claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5, gemini-2.5-pro, gemini-2.5-flash. Document refresh cadence in the new guide.
+- Public docs `docs/guides/tracking-llm-cost.md` exists and matches the implemented behaviour.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+- **Ship a default price map or refuse to estimate?** Recommendation: **ship default, mark as estimate.** The cost gap is a perception problem; refusing to estimate would re-open it. Public docs make the estimation explicit.
+- **Per-token vs per-call pricing.** Some models (e.g., image gen) bill per request. Out of scope for v1 — flag in the new doc page that defrost only handles per-token text models. Add image/audio in a follow-up spec when the demand surfaces.
+- **Currency.** USD only in v1. Add `--currency` later if needed.
+- **Cost regressions in PRs.** Mentioned in §2 as a follow-up. Specced separately when prioritised — don't bloat this spec.
+- **Where does `--prices` config land on disk for `defrost serve`?** Recommendation: `~/.config/defrost/prices.yaml` if the flag is unset and the file exists. Otherwise bundled defaults. Spec the precedence: `--prices` flag > `~/.config/defrost/prices.yaml` > bundled.

--- a/docs/_internal/specs/2026-05-05-datasets.md
+++ b/docs/_internal/specs/2026-05-05-datasets.md
@@ -1,0 +1,252 @@
+# Spec #3 — Datasets
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation.
+**Phase:** 2 — datasets primitive.
+
+## 1. Goal
+
+A first-class "dataset" primitive matching what LangSmith and Langfuse call by the same name: a versioned set of `{input, expected, metadata}` rows that evals run against. Captured from production traces, versioned in git on the data branch, and runnable via CLI as a wrapper over an arbitrary eval command.
+
+A user can:
+
+1. Create a named dataset.
+2. Add rows from a JSONL file or directly from production trace spans.
+3. List versions; show a specific version.
+4. Run any command once per row, with row data injected via env vars.
+5. Diff dataset versions in a PR (`git diff`).
+
+## 2. Why this matters competitively
+
+After tracing, datasets are the second-most-visible primitive in both LangSmith and Langfuse. The "capture interesting prod traces, codify them as a regression set, run the new model against the same set" workflow is the default eval flow both products push.
+
+defrost has the unique angle: **datasets live on the data branch as JSONL, so `git diff main..feature -- datasets/` shows exactly which rows changed in a PR.** Neither incumbent can match this without becoming a different product.
+
+## 3. Public docs to write first
+
+- **New page:** `docs/guides/datasets.md` — "Capture, version, run." 1-screen walkthrough. Sections: "Create a dataset", "Add rows (jsonl, capture-from-trace)", "Pin to a version", "Run an eval against a dataset", "Diff a dataset across PRs". Stay neutral.
+- **New page:** `docs/reference/cli/dataset.md` — full CLI reference for the new `defrost dataset` subcommand and its sub-subcommands. Mirror the structure of `docs/reference/cli/exec.md`.
+- **New concept page:** `docs/concepts/datasets.md` — short (≤300 words) explanation of why datasets live on the data branch (versioning is git, capture is from existing trace files, etc.). Cite `docs/concepts/git-as-database.md` and `docs/concepts/defrost-branch.md`.
+- **Edit:** `docs/index.md` — add datasets to the feature list.
+- **Edit:** `docs/reference/storage-layout.md` — add a `datasets/` section to the directory tree, mirroring how `traces/`, `metrics/`, `logs/`, and `suppressions.json` are documented.
+- **Edit:** `docs/reference/serve-api.md` — document the new `/api/datasets/*` endpoints.
+
+## 4. Storage layout
+
+On the data branch (committed):
+
+```text
+<repo>/.defrost/
+├── datasets/
+│   ├── <name>/
+│   │   ├── metadata.json
+│   │   └── versions/
+│   │       ├── v1.jsonl
+│   │       ├── v2.jsonl
+│   │       └── latest        (text file containing the current version filename, e.g. "v2.jsonl")
+│   └── ...
+└── ...
+```
+
+`<name>` is restricted to `[a-z0-9_-]+` (lowercase URL-friendly). Reuse `persist.EncodeName` / `DecodeName` if a richer charset is needed in the future, but v1 enforces the strict charset to keep filesystem & URL behaviour predictable.
+
+### `metadata.json`
+
+```json
+{
+  "schema": 1,
+  "name": "summarization-eval",
+  "description": "Customer-support summarization regression set",
+  "row_schema": { "input": "string", "expected": "string|null" },
+  "created_at": "2026-05-05T12:00:00Z",
+  "created_by": "alice@example.com"
+}
+```
+
+`row_schema` is informational in v1 (no enforcement). Reserve the field for future schema validation.
+
+### `versions/vN.jsonl`
+
+One JSON object per line:
+
+```json
+{ "id": "<sha256>", "input": <any>, "expected": <any|null>, "metadata": {"source_trace_id": "...", "source_span_id": "...", "captured_at": "..."} }
+```
+
+- `id` is a deterministic content hash so the same input is the same row across versions and across teammates' captures. `id = sha256(canonical_json({"input": X, "expected": Y}))[:16]`.
+- `expected` is **optional**. Datasets can be collection-only, with labels added later (see open question §12).
+- `metadata.source_trace_id` is set when the row originated from a trace via `defrost dataset add --from-trace`.
+
+### Version lifecycle
+
+- `defrost dataset create <name>` writes `metadata.json` and an empty `versions/v1.jsonl`. Sets `latest` → `v1.jsonl`.
+- `defrost dataset add` (any source) appends to a working copy of the latest version *in memory*, then writes a new `versions/v(N+1).jsonl` with the union, atomic-rename, and updates `latest`. **Versions are immutable once written** — a subsequent `add` always creates v(N+1).
+- `defrost dataset add` is idempotent on `id`: adding a row that's already in the latest version is a no-op (no new version created).
+
+This keeps `git diff` clean: a v3 is always the union of v2 plus exactly the rows the user added in that command. Reverting a dataset is `git revert` of the relevant data-branch commit.
+
+### Atomic write & conflict handling
+
+Same model as `suppressions.json`: clone-mutate-push via the existing helpers in `internal/persist/persist.go`. On non-fast-forward push, fetch + replay the mutation against the new tip and retry (up to 5 attempts). Document the retry budget in `docs/reference/cli/dataset.md`.
+
+## 5. CLI surface
+
+New top-level command: `defrost dataset`. Subcommands:
+
+### `defrost dataset create <name> [--description <text>] [--schema <file>]`
+
+Create a new dataset. Fails if `<name>` already exists. `--schema` accepts a JSON file with the row schema (informational only in v1).
+
+### `defrost dataset add <name> --from-jsonl <file>`
+
+Append rows from a local JSONL file. Each line must parse as `{input, expected?, metadata?}`. Rows already present (by `id`) are skipped. Prints `+ N rows, M skipped (duplicates)` + the new version filename.
+
+### `defrost dataset add <name> --from-trace <trace-id> [--span <name-glob>] [--input-attr <path>] [--expected-attr <path>]`
+
+Capture rows from a stored trace. Walks the trace tree (reusing `query.QuerierWithTraceTree.LookupTrace` from spec #1). For each span matching `--span` (default: `gen_ai.*`):
+
+- `input` ← attribute named by `--input-attr` (default: `gen_ai.request.input` or `gen_ai.prompt` — try both).
+- `expected` ← attribute named by `--expected-attr` (optional; omitted if absent).
+- `metadata.source_trace_id` ← `<trace-id>`; `metadata.source_span_id` ← span ID.
+
+If no spans match, exit 1 with a clear error.
+
+### `defrost dataset add <name> --from-runs --filter <expr>`
+
+Capture from many recent runs at once. `<expr>` is a tiny attribute-match DSL (e.g., `model=claude-opus-4-7 status=fail`). v1 supports key=value AND-ed; defer richer expressions.
+
+### `defrost dataset list`
+
+Print all datasets, one per line: `<name>\t<latest-version>\t<row-count>\t<created-at>`. Add `--json` for NDJSON output.
+
+### `defrost dataset show <name> [--version <vN|latest>] [--json]`
+
+Print rows. Default: human-readable, truncated. `--json` outputs raw JSONL.
+
+### `defrost dataset run <name> [--version <vN|latest>] -- <command>`
+
+The headline command. Runs `<command>` once per row, with these env vars set:
+
+- `DEFROST_DATASET_NAME` — dataset name
+- `DEFROST_DATASET_VERSION` — version string (e.g. `v2.jsonl`)
+- `DEFROST_DATASET_ROW_ID` — the row's `id`
+- `DEFROST_DATASET_ROW_INDEX` — 0-based index in the version
+- `DEFROST_DATASET_INPUT` — the row's `input`, JSON-serialized
+- `DEFROST_DATASET_EXPECTED` — the row's `expected` if present, JSON-serialized
+
+Each invocation is wrapped by the existing `defrost exec` machinery (see `internal/runner/exec.go`), so each row gets its own trace, recorded automatically. The user's command sees a normal child-process environment and can emit OTel spans / metrics in the usual way.
+
+Flags:
+
+- `--parallel <N>` — run N invocations concurrently. Default 1.
+- `--limit <N>` — only run the first N rows.
+- `--shuffle` — shuffle row order (for sampling).
+
+Exit code: 0 if all rows succeeded; otherwise the first non-zero child exit code, with a per-row summary table on stderr.
+
+### `defrost dataset diff <name> <ref-a> <ref-b>`
+
+Sugar for `git diff <ref-a> <ref-b> -- datasets/<name>/` on the data branch. Pretty-prints added / removed rows.
+
+## 6. HTTP API surface
+
+All under `internal/serve/`, in a new file `internal/serve/datasets.go`.
+
+| Method + path | Returns |
+|---|---|
+| `GET /api/datasets` | `{datasets: [{name, latest_version, row_count, created_at}]}` |
+| `GET /api/datasets/{name}` | `{name, description, latest_version, versions: [{id, row_count, created_at, commit}]}` |
+| `GET /api/datasets/{name}/versions/{vN}` | `{rows: [...]}` (rows from that version) |
+| `POST /api/datasets/{name}/rows` | Append row(s) to a new version. Body: `{rows: [{input, expected?, metadata?}], from_trace_id?: "..."}`. Returns the new version. Used by the dashboard's "Add to dataset" UI. |
+| `POST /api/datasets` | Create dataset. Body: `{name, description?, row_schema?}`. Returns 201 + `{name}`. |
+
+Cache-Control:
+
+- `GET /api/datasets` and `GET /api/datasets/{name}` → `public, max-age=60`.
+- `GET /api/datasets/{name}/versions/{vN}` → `public, max-age=86400` (versions are immutable).
+- POSTs → no caching.
+
+POST handlers reuse the existing `persist.New(opts)` backend and the `UpdateSuppressions`-style commit-and-push pattern. Add an analogous helper to `internal/persist/persist.go`:
+
+```go
+func (b *Backend) AppendDatasetRows(name string, rows []DatasetRow, msg string) (newVersion string, err error)
+func (b *Backend) CreateDataset(name string, meta DatasetMetadata) error
+```
+
+## 7. Web UI surface
+
+| File | Role |
+|---|---|
+| `web/src/pages/Datasets.tsx` (new) | List view at `/datasets`. Table of datasets with row counts and last-updated. |
+| `web/src/pages/DatasetDetail.tsx` (new) | Detail view at `/datasets/:name`. Version picker (dropdown), rows table (virtualized at >1k rows). "Add row" button opens a modal. |
+| `web/src/components/AddToDatasetButton.tsx` (new) | Mounted on `SpanDetail` (from spec #1). Opens a modal: pick existing dataset or create new, optional `expected` value. POSTs `/api/datasets/{name}/rows` with the span's input. |
+| `web/src/App.tsx` | Add `/datasets` and `/datasets/:name` routes. |
+| `web/src/api.ts` | `listDatasets`, `getDataset`, `getDatasetVersion`, `appendDatasetRows`, `createDataset` typed wrappers. |
+
+Navigation: top nav gains a "Datasets" link next to the existing dashboard / heatmap link.
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/persist/persist.go`, `cache.go`, `suppress.go` | Pattern for clone-mutate-push commit logic. The `UpdateSuppressions(mutate, msg)` shape maps directly to dataset row appends. Reuse `EncodeName`/`DecodeName` for path-escape if dataset names ever need a wider charset (defer; v1 strict charset). |
+| `internal/runner/exec.go`, `runner/adapter.go` | `dataset run` wraps this. Each row is a normal `defrost exec` child invocation — no new exec path. |
+| `internal/cli/cli.go`, `wire.go`, `runtime.go` | Existing kong command registration + wire DI. Add the `Dataset` command following the `Suppress` and `Drop` patterns. |
+| `internal/serve/server.go` | Add the new endpoints; split into `internal/serve/datasets.go` to keep `server.go` lean (mirrors how `drop.go`, `metrics.go` already live). |
+| `internal/query/duckdb/` | For `--from-trace` capture, reuse `LookupTrace` (spec #1). Don't introduce a new ingest path. |
+| `web/src/components/SpanDetail.tsx` (spec #1) | Mount the new `AddToDatasetButton` here. |
+| `web/src/components/RunDetailSheet.tsx` | Existing right-side sheet pattern for the "Add row" modal. |
+
+**New files only:**
+
+- `internal/dataset/` — pure logic (validation, row hashing, JSONL marshaling). Files: `dataset.go`, `row.go`, `dataset_test.go`, `row_test.go`.
+- `internal/persist/dataset.go` (+ `dataset_test.go`) — git-write helpers.
+- `internal/serve/datasets.go` (+ `datasets_test.go`)
+- `internal/cli/dataset.go` (+ `dataset_test.go`) — kong subcommand + handler.
+- `web/src/pages/Datasets.tsx`, `DatasetDetail.tsx`, with `*.test.tsx` siblings.
+- `web/src/components/AddToDatasetButton.tsx` (+ test).
+- Public docs as listed in §3.
+
+## 9. OTel emission
+
+`defrost dataset run` emits one parent span per overall invocation and one child span per row, on top of the existing per-row `defrost exec` instrumentation. Span attributes:
+
+- `defrost.dataset.name`
+- `defrost.dataset.version`
+- `defrost.dataset.row_id`
+- `defrost.dataset.row_index`
+
+These are namespaced under `defrost.*` because no OTel semantic convention covers "I'm running an eval over a dataset row." If/when one lands upstream, migrate.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/dataset/dataset_test.go` | Row hashing is deterministic. Canonical JSON ordering (object keys sorted). Adding the same row twice produces the same `id`. |
+| `internal/dataset/row_test.go` | JSONL marshal/unmarshal round-trips. Optional `expected` field handled. |
+| `internal/persist/dataset_test.go` | `CreateDataset` writes the expected files. `AppendDatasetRows` produces a new version on disk; idempotent on duplicates; concurrent writers retry on non-FF and converge. |
+| `internal/serve/datasets_test.go` | All five endpoints return the expected JSON shapes. Cache headers correct. POSTs persist via a stub backend. |
+| `internal/cli/dataset_test.go` | `dataset create` / `add --from-jsonl` / `list` / `show` / `run -- <cmd>` end-to-end against a temp repo. `run` invokes the child once per row, with env vars set. `--limit` and `--shuffle` honored. |
+| `web/src/pages/Datasets.test.tsx`, `DatasetDetail.test.tsx`, `components/AddToDatasetButton.test.tsx` | Render, fetch, and POST flows against MSW or fetch stubs. |
+
+## 11. Acceptance criteria
+
+- A user can create a dataset, add rows from a JSONL file, add rows from a captured trace, and run an arbitrary command once per row, all from the CLI.
+- Each dataset run writes a new version on the data branch; existing versions are never mutated.
+- Re-running `add` with the same rows produces no new version (idempotent on `id`).
+- `git diff main..feature -- .defrost/datasets/` shows exactly which rows were added/removed in a PR.
+- The dashboard `/datasets` page lists datasets, lets the user pick a version, and shows the rows.
+- An "Add to dataset" button on the trace tree's `SpanDetail` panel captures a row in one click.
+- `defrost dataset run` integrates with `defrost exec` so each row's child invocation is automatically traced — appears in the heatmap and the trace tree without extra wiring.
+- Public docs at `docs/guides/datasets.md`, `docs/concepts/datasets.md`, and `docs/reference/cli/dataset.md` exist and match the implementation.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+- **Optional `expected`.** Recommendation: yes, allow collection-only datasets. Use case: a researcher captures interesting prod inputs, then labels later in batch (via spec [`#8 annotations-feedback`](./2026-05-05-annotations-feedback.md)). Specced as optional throughout.
+- **Schema enforcement.** Recommendation: informational in v1, real validation when a user pain point shows up. Defer.
+- **Dataset deletion.** Recommendation: **don't add `defrost dataset delete` in v1.** Use `git revert` on the data branch. If real demand surfaces, add a thin wrapper that writes a delete commit. We never want a CLI command that destroys evidence.
+- **Row size limit.** Practically the OTLP-protobuf-on-git story breaks down past ~1MB per row. Recommendation: warn in `dataset add` if any row exceeds 256KB; hard-fail at 1MB. Document in the new guide.
+- **Capture-from-trace heuristics.** OTel `gen_ai.*` semantic conventions are still settling; the attribute name we want for "input" varies (`gen_ai.prompt`, `gen_ai.request.input`, `gen_ai.input.messages`). Recommendation: try a fixed list in order and pick the first present; expose `--input-attr` for explicit control. Keep the list current as the spec evolves.
+- **Cross-repo datasets.** A team might want one canonical dataset reused by N repos. Hosted-tier territory (see parent §7). Don't try to solve in v1.

--- a/docs/_internal/specs/2026-05-05-eating-the-cake.md
+++ b/docs/_internal/specs/2026-05-05-eating-the-cake.md
@@ -1,0 +1,194 @@
+# Eating the cake — defrost vs LangSmith and Langfuse
+
+**Date:** 2026-05-05
+**Status:** Strategy & roadmap. Parent doc for the build specs in this directory dated 2026-05-05.
+**Audience:** internal contributors. Public docs stay neutral — see §8.
+
+## 1. TL;DR
+
+defrost's wedge is six bullets long:
+
+- **OTel-native.** The wire protocol is OTLP. Any language with an OTel SDK is already a defrost client.
+- **Git-native.** No database to operate. `<repo>/.defrost/` is the storage; replication, auth, encryption, and backup are inherited from the user's git host.
+- **$0.** No per-trace tax, no per-seat tax, no retention tax. Self-host is the default, not the upsell.
+- **No SDK lock-in.** Migrate in or out by changing `OTEL_EXPORTER_OTLP_ENDPOINT`.
+- **History travels with code.** Eval diffs are PR-diffable. `git diff main..feature -- .defrost/` shows exactly which traces, scores, and metrics moved.
+- **We grow with you.** Git is the right answer up to ~GB-scale history. Beyond that, the architecture already pre-figures a swap-in (`query.Querier` in `internal/query/iface.go` was designed for it). When users outgrow git, we'll build the next tier *with them* — not abandon them at the limit.
+
+That last bullet is a commitment, not a caveat. See §7.
+
+## 2. Why the incumbents are vulnerable
+
+### LangSmith — the SaaS pricing story
+
+- **$39/seat/mo + $0.50 per 1k base traces.** Five engineers cost $195/mo before any traces ingest.
+- **14-day default retention.** Extending to 400 days **doubles** the per-trace price.
+- **Feedback / annotations silently auto-upgrade traces** to a more expensive tier — the more your team annotates, the more you pay.
+- **No self-host below Enterprise.** No middle ground between SaaS and a sales call.
+- **Closed source.** No code review of the storage layer, no air-gap option.
+- Customers routinely sample down to **0.1%** of traffic to control cost — i.e., they're paying for an observability product that they then choose to be 99.9% blind for.
+
+### Langfuse — the operational complexity story
+
+Langfuse already won the "OSS LangSmith alternative" narrative. Where they're vulnerable is *operations*:
+
+- **Self-host stack: ClickHouse + Postgres + Redis + S3/blob + ≥2 containers.** Co-founder publicly concedes ClickHouse adds ops anxiety.
+- "Easy" path is Docker Compose on a VM, only fine for ≤1M traces/mo. Production scale needs Helm or Terraform.
+- **EE features paywalled in self-host.** SSO, RBAC, scheduled exports, UI customization sit behind a $300/mo Teams add-on or $2,499/mo Enterprise tier.
+- **Cloud Hobby:** 50k units/mo, 30-day retention, 2 users — and the data lives in their cloud.
+- **Doesn't travel with code.** No PR diffs, no git history, no `git blame` on a regression in eval scores.
+
+## 3. Feature map ranked by popularity
+
+LangSmith and Langfuse have converged on the same feature surface. Rank applies to both unless noted.
+
+### Tier S — the reason people log in
+
+These are the features users encounter on their first session. Without them defrost doesn't get a demo.
+
+1. **Trace tree visualization** — waterfall + nested spans + span detail panel.
+2. **Datasets** — capture-from-trace → versioned test set → re-run.
+3. **Evaluations** — LLM-as-judge, heuristic, custom evaluators.
+4. **Prompt management + Playground** — version, edit, compare across models.
+
+### Tier A — heavy use, but not the first-login feature
+
+5. **Annotation queues / scores / user feedback** — structured human feedback workflow.
+6. **Cost & token tracking** — auto-surfaced in UI.
+7. **Monitoring / time-series analytics** — latency, error rate, cost over time.
+8. **Pairwise comparison** — A/B prompts, A/B models.
+
+### Tier B — enterprise / nice-to-have
+
+9. **Deployments / hosted serving** — LangGraph Cloud territory. *Skip.* defrost is observability + eval, not orchestration.
+10. **RBAC, orgs, SSO** — Langfuse paywalls these; LangSmith reserves them for Enterprise. defrost's answer: hosted-tier territory (§7).
+11. **Shared / public datasets, prompt sharing across orgs** — hosted-tier territory.
+
+### Tier B+ — Langfuse-specific
+
+- **Server-side LLM-as-judge.** Langfuse runs judges as a managed service. defrost matches with a CLI / library that emits standard OTel — see spec [`2026-05-05-llm-as-judge.md`](./2026-05-05-llm-as-judge.md).
+- **Sessions / users grouping.** Already representable in our OTel pipeline via `session.id` / `user.id` resource attributes. UI surfacing only — see spec [`2026-05-05-sessions-users.md`](./2026-05-05-sessions-users.md).
+
+## 4. Gap matrix
+
+| Feature | defrost today | LangSmith | Langfuse | Verdict |
+|---|---|---|---|---|
+| OTel ingestion (any language) | ✅ embedded OTLP receiver (`internal/otlp/`) | ⚠️ SDK preferred | ✅ OTel + SDKs | parity |
+| Storage backend | ✅ git, zstd OTLP protobuf | proprietary | ClickHouse + Postgres + Redis + S3 | **defrost wins on simplicity** |
+| Ops burden (self-host) | **zero** (git only) | n/a (SaaS) | ≥4 services + ops | **defrost wins** |
+| Trace tree UI | ⚠️ heatmap only (`web/src/`) | ✅ best-in-class | ✅ very good | **biggest UX gap** |
+| Cost / token surfacing | ⚠️ data captured, not shown | ✅ first-class | ✅ first-class | UI gap only |
+| Datasets | ❌ none | ✅ versioned | ✅ versioned | **gap** |
+| Evals (test runners) | ✅ Go, pytest, Jest, Vitest, Inspect AI, Promptfoo | partial | partial | **defrost wins on breadth** |
+| LLM-as-judge primitive | ❌ | ✅ | ✅ (server-side) | gap |
+| Prompt management | ❌ | ✅ | ✅ + caching | gap |
+| Playground | ❌ | ✅ | ✅ | gap |
+| Annotations / feedback | ❌ | ✅ | ✅ (scores) | gap |
+| Pairwise comparison | ❌ | ✅ | ✅ | gap |
+| Sessions / users grouping | ⚠️ via OTel attrs, no UI | ✅ | ✅ | UI gap only |
+| Monitoring dashboards | ⚠️ basic charts | ✅ rich | ✅ rich | partial |
+| PR-diffable evals (history travels with code) | ✅ unique | ❌ | ❌ | **defrost wins, structural** |
+| Air-gapped / offline CI | ✅ unique | ❌ | ⚠️ heavy stack | **defrost wins** |
+| Slim CI binary (`defrost-ci`) | ✅ unique | ❌ | ❌ | **defrost wins** |
+| Open source | ⚠️ license unset (see §8) | ❌ closed | ✅ MIT | **must license to match** |
+| Per-trace pricing | $0 | $0.50/1k + extras | $0 self-host / $8 per 100k cloud | parity vs Langfuse self-host, win vs the rest |
+| SSO / RBAC | ❌ | Enterprise only | EE add-on ($300/mo) | gap (hosted-tier) |
+| Cross-project rollups | ❌ per-repo | ✅ | ✅ | hosted-tier territory |
+
+## 5. Structural advantages
+
+### vs LangSmith — they cannot match without rebuilding
+
+1. **Pricing.** $0 forever for self-host. No per-trace tax, no retention tax, no surprise tier upgrades. Sample at 100%.
+2. **OSS** (once licensed — see §8). No closed-source review. No vendor risk.
+3. **No SDK lock-in.** OTel is the wire format.
+
+### vs Langfuse — the unique wedge
+
+4. **Zero-ops storage.** Git is the database. No ClickHouse, no Postgres, no Redis, no S3, no Helm chart. The "5-minute Docker Compose" path Langfuse markets is still 5 minutes more than `git init`.
+5. **History travels with code.** Eval regressions are `git blame`-able. PR diffs include score diffs.
+6. **Air-gapped CI.** No outbound network, no DB container. Critical for regulated environments.
+7. **Slim CI variant.** `defrost-ci` is ~1/3 the size — no DuckDB, no web bundle.
+
+### vs both
+
+8. **Test-runner breadth.** Go, pytest, Jest, Vitest, Inspect AI, Promptfoo already shipped. Both incumbents leave most of these to the user.
+9. **Single static binary install.** No package manager, no service mesh, no migration path.
+
+## 6. Roadmap
+
+Each phase delivers a credible demo against the incumbents. Specs are numbered #1–#10; each is self-contained and dispatchable to a sub-agent. Phase order is build order; specs within a phase can be parallelised.
+
+| Phase | Specs | Demo deliverable |
+|---|---|---|
+| 1 — close the trace UX gap | [`#1 trace-tree-ui`](./2026-05-05-trace-tree-ui.md), [`#2 cost-token-surfacing`](./2026-05-05-cost-token-surfacing.md) | "I can debug a 500-span trace with token + cost on every row." |
+| 2 — datasets primitive | [`#3 datasets`](./2026-05-05-datasets.md) | "I capture interesting prod traces into a versioned dataset and re-run." |
+| 3 — evals as first-class | [`#4 llm-as-judge`](./2026-05-05-llm-as-judge.md), [`#5 pairwise-comparison`](./2026-05-05-pairwise-comparison.md) | "I score outputs with an LLM judge and compare runs side-by-side." |
+| 4 — prompts + playground | [`#6 prompt-management`](./2026-05-05-prompt-management.md), [`#7 playground`](./2026-05-05-playground.md) | "I edit a prompt in the dashboard, run it across three models, and the run shows up in the trace tree." |
+| 5 — feedback + observability polish | [`#8 annotations-feedback`](./2026-05-05-annotations-feedback.md), [`#9 sessions-users`](./2026-05-05-sessions-users.md), [`#10 monitoring-dashboards`](./2026-05-05-monitoring-dashboards.md) | "I review last week's bad runs in an annotation queue, and I have prod monitoring on cost / latency / error rate." |
+
+After Phase 5, defrost has feature parity on the Tier S + Tier A surface from §3. Tier B (RBAC, cross-project rollups) is hosted-tier territory.
+
+## 7. Scaling story — grow with you
+
+Git as a database has a ceiling: practically, ~1–2 GB of accumulated history per repo before push frequency, fetch cost, and dashboard load times start hitting protocol limits (this is documented in [`docs/reference/storage-layout.md`](../../reference/storage-layout.md)). That ceiling is real.
+
+The framing is **not** "this is the cap, take it or leave it." The framing is:
+
+> Git is what we focus on now. Git is the right answer for almost every team that doesn't already operate ClickHouse and isn't planning to. **When you outgrow git, we will build the next tier with you** — clustered storage, server-side query, multi-tenant data branches, auth, RBAC, billing. The architecture is already pre-figured for it.
+
+Concrete pre-figuring already in the codebase:
+
+- `internal/query/iface.go` defines a `query.Querier` interface — `internal/query/duckdb/` is one impl. The package comment in `internal/serve/server.go` states explicitly: *"a hosted-defrost ClickHouse implementation will plug in here without changes."*
+- All read paths go through that interface. None of the dashboard code knows about git or DuckDB.
+- All write paths go through `internal/persist/`. A hosted impl plugs in there.
+- OTLP ingestion (`internal/otlp/`) is already wire-compatible with any storage backend.
+
+**Sketches of the hosted tier (design only, NOT in scope here):**
+
+- **Multi-tenant data branches.** One git remote per org/project. Or a hosted-only ClickHouse-backed `query.Querier` with the same wire shape. Either way, no breaking change for self-host users.
+- **Server-side query API.** Hosted clusters expose `/api/query` for cross-project rollups, retention windowing, etc. Self-host stays local-DuckDB.
+- **Auth/RBAC.** Layered above the existing handlers (middleware, not a rewrite). Self-host: passthrough (single-user, loopback).
+- **Billing.** Per-org, usage-based on traces stored × retention days. Mirror Langfuse Pro's $199/mo for an unlimited-seats baseline so we don't get out-priced.
+
+These bullets are scaffolding for the conversation when users hit the git ceiling — not a v1 work item. Spec future hosted-tier work in its own dated spec when the conversation becomes real.
+
+## 8. Blockers
+
+### License is unset
+
+defrost has no `LICENSE` file at the repo root. Until that's fixed, we can't credibly market as the "OSS alternative" — Langfuse will out-position us on day one with their MIT license. **Recommendation: Apache 2.0** (preferred for the patent grant). MIT is acceptable if matching Langfuse exactly is the priority.
+
+This blocks marketing, not engineering. Specs #1–#10 can be built before the license lands.
+
+### Public-docs guardrails
+
+The user-facing docs at `docs/index.md`, `docs/concepts/`, `docs/guides/`, `docs/reference/` must stay neutral. **Never name LangSmith or Langfuse** in public docs. Public docs lead with:
+
+- OTel-native ingestion (works with anything that emits OTLP)
+- Git-native storage (no DB to operate)
+- $0, self-host by default
+- History travels with code
+
+Migration / comparison pages may be added later as `docs/guides/coming-from-langsmith.md` and `docs/guides/coming-from-langfuse.md`. Those are out of scope for the current spec batch.
+
+### Heatmap deprecation path
+
+The current `Grid` view in `web/src/components/Grid.tsx` is the test-run heatmap. The trace tree from spec #1 lives alongside it (per-run drill-down), not as a replacement. Both stay. If usage data later shows the heatmap is dead, deprecate it in a follow-up spec.
+
+## Appendix — index of build specs in this batch
+
+All under `docs/_internal/specs/`, all dated 2026-05-05.
+
+| # | File | Phase |
+|---|---|---|
+| 1 | [`2026-05-05-trace-tree-ui.md`](./2026-05-05-trace-tree-ui.md) | 1 |
+| 2 | [`2026-05-05-cost-token-surfacing.md`](./2026-05-05-cost-token-surfacing.md) | 1 |
+| 3 | [`2026-05-05-datasets.md`](./2026-05-05-datasets.md) | 2 |
+| 4 | [`2026-05-05-llm-as-judge.md`](./2026-05-05-llm-as-judge.md) | 3 |
+| 5 | [`2026-05-05-pairwise-comparison.md`](./2026-05-05-pairwise-comparison.md) | 3 |
+| 6 | [`2026-05-05-prompt-management.md`](./2026-05-05-prompt-management.md) | 4 |
+| 7 | [`2026-05-05-playground.md`](./2026-05-05-playground.md) | 4 |
+| 8 | [`2026-05-05-annotations-feedback.md`](./2026-05-05-annotations-feedback.md) | 5 |
+| 9 | [`2026-05-05-sessions-users.md`](./2026-05-05-sessions-users.md) | 5 |
+| 10 | [`2026-05-05-monitoring-dashboards.md`](./2026-05-05-monitoring-dashboards.md) | 5 |

--- a/docs/_internal/specs/2026-05-05-llm-as-judge.md
+++ b/docs/_internal/specs/2026-05-05-llm-as-judge.md
@@ -1,0 +1,248 @@
+# Spec #4 — LLM-as-judge primitive
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation. Builds on [`#3 datasets`](./2026-05-05-datasets.md).
+**Phase:** 3 — evals as first-class.
+
+## 1. Goal
+
+A defrost-native LLM-as-judge primitive: a configurable evaluator that runs a judge prompt over an `(input, output)` pair and emits a score plus reasoning. Configurations live on the data branch as YAML; runs emit standard OTel spans tagged with `gen_ai.evaluation.*` so the same trace tree (spec #1), cost surfacing (spec #2), and dataset machinery (spec #3) light up for free.
+
+A user can:
+
+1. Define a judge config (model, prompt, score schema) on the data branch.
+2. Run the judge against any captured trace span, or against a dataset.
+3. See judge scores as a column on the trace tree and on dataset run summaries.
+
+## 2. Why this matters competitively
+
+LLM-as-judge is the workhorse evaluator pattern in 2026. LangSmith ships it as a built-in. Langfuse runs judges as a managed service.
+
+defrost's angle: judges run **client-side** (CLI or `defrost serve` with user-supplied keys), emit **standard OTel** with `gen_ai.evaluation.*` semantic conventions, and persist via the **same git pipeline** as everything else. There's no new storage backend, no service to operate, and the score data is `git diff`-able alongside the dataset rows it scored.
+
+This also closes the Langfuse-specific gap of "server-side LLM-as-judge" — defrost matches the workflow without operating an inference server.
+
+## 3. Public docs to write first
+
+- **New page:** `docs/guides/llm-as-judge.md` — "Score outputs with an LLM judge." Sections: "Define a judge", "Run against a trace", "Run against a dataset", "Read judge scores in the dashboard", "Reproducibility caveats".
+- **New page:** `docs/reference/cli/judge.md` — full CLI reference.
+- **New concept page:** `docs/concepts/evaluators.md` — short page covering the relationship between datasets, judges, and the existing test runners. Make clear that judges are *one* type of evaluator; existing runners (Inspect AI, Promptfoo, etc.) are others.
+- **Edit:** `docs/reference/storage-layout.md` — add `judges/` to the directory tree.
+- **Edit:** `docs/reference/serve-api.md` — document new endpoints.
+
+## 4. Storage layout
+
+On the data branch:
+
+```text
+<repo>/.defrost/judges/
+├── <name>.yaml
+└── ...
+```
+
+`<name>.yaml`:
+
+```yaml
+schema: 1
+name: helpfulness-v1
+description: Scores helpfulness of a customer-support reply on a 0–5 scale
+model: anthropic/claude-opus-4-7
+system_prompt: |
+  You are an evaluator. Given a customer question and an agent reply,
+  score the reply for helpfulness on a 0–5 scale...
+user_prompt_template: |
+  Question: {{input}}
+  Reply:    {{output}}
+  Return JSON: {"score": <0-5>, "reason": "<short>"}
+score_schema:
+  type: scalar          # scalar | categorical
+  range: [0, 5]
+temperature: 0.0
+max_tokens: 256
+```
+
+Judge **runs** are stored only as OTel trace files (the canonical traces in `traces/<YYYY>/<MM>/<DD>/...otlp.pb.zst`) — no separate `judge_runs/` directory. The judge span has attributes:
+
+- `gen_ai.evaluation.judge_name` — `<name>`
+- `gen_ai.evaluation.judge_version` — git SHA of the judge YAML at run time
+- `gen_ai.evaluation.score` — float
+- `gen_ai.evaluation.label` — for categorical judges
+- `gen_ai.evaluation.reason` — string
+- `gen_ai.evaluation.target_trace_id` — the trace this judge scored
+- `gen_ai.evaluation.target_span_id` — optional, when scoring a single span
+
+`gen_ai.evaluation.*` is **not** an upstream OTel semantic convention as of today. Document explicitly that defrost is squatting on this namespace pending an upstream RFC, and contribute one. Reference the OTel SemConv repo from the new docs page so contributors can track the upstream conversation.
+
+## 5. CLI surface
+
+`defrost judge` parent command. Subcommands:
+
+### `defrost judge create <name> --model <m> --prompt <file> [--score scalar|categorical] [--range <min,max>]`
+
+Write `judges/<name>.yaml`. `--prompt` accepts a file containing the user prompt template (with `{{input}}` and `{{output}}` placeholders). System prompt can be passed via `--system-prompt <file>` or defaulted.
+
+### `defrost judge edit <name>`
+
+Open `$EDITOR` on `judges/<name>.yaml`. Validate before commit.
+
+### `defrost judge list [--json]`
+
+List judges. Default: `<name>\t<model>\t<score-schema>`.
+
+### `defrost judge show <name> [--ref <git-ref>]`
+
+Print the YAML at HEAD or at a specific ref. Useful for "what scoring did we use back then?"
+
+### `defrost judge run <name> --trace <trace-id> [--span <span-id>]`
+
+Score a single trace. If `--span` is omitted, scores the run's root user-visible LLM span (heuristic: deepest descendant with `gen_ai.usage.*` attributes; if ambiguous, fail with a clear error and require `--span`). The judge's input/output is extracted from the target span:
+
+- `input` ← `gen_ai.request.input` / `gen_ai.prompt` / `gen_ai.input.messages` (try in order)
+- `output` ← `gen_ai.response.output` / `gen_ai.completion` / `gen_ai.response.text`
+
+Emits a new trace span recorded under the same machinery as `defrost exec`. Prints the score to stdout.
+
+### `defrost judge run <name> --dataset <dataset> [--version <vN|latest>]`
+
+Score every row in a dataset. For each row, the judge is invoked with `input = row.input`, `output = row.expected` (or `row.metadata.actual_output` if set). Wraps `defrost dataset run` from spec #3 — i.e., judges are just another command you can run against a dataset.
+
+Flags: `--parallel <N>`, `--limit <N>`, `--api-key <env-var-name>`. The api-key flag is the **name** of an env var defrost should read at child-process exec time (e.g., `--api-key ANTHROPIC_API_KEY`). The key itself never appears in process args, never in logs, never on disk.
+
+### `defrost judge` Go library
+
+`internal/eval/judge/`:
+
+```go
+package judge
+
+type Judge struct { /* loaded from <repo>/.defrost/judges/<name>.yaml */ }
+
+type Score struct {
+    Value     float64
+    Label     string  // for categorical
+    Reason    string
+    JudgeName string
+    JudgeRef  string  // git SHA of YAML at score time
+}
+
+func Load(name string) (*Judge, error)
+func (j *Judge) Score(ctx context.Context, input, output string) (Score, error)
+```
+
+Internal users (e.g., the Inspect AI / Promptfoo adapters in `internal/eval/`) can call `judge.Load(...).Score(...)` directly without the CLI — same OTel emission, same persistence.
+
+### Python helper
+
+Distribute via the existing pytest-plugin pattern at `internal/runner/python/pytest/`. Provide `defrost.judge(name).score(input, output)` callable so judge invocation looks the same in pytest fixtures as it does in Go.
+
+## 6. HTTP API surface
+
+In `internal/serve/judges.go`:
+
+| Method + path | Returns |
+|---|---|
+| `GET /api/judges` | `{judges: [{name, model, score_schema, updated_at}]}` |
+| `GET /api/judges/{name}?ref=<git-ref>` | The full YAML config at HEAD or ref |
+| `POST /api/judges/{name}/run` | Body: `{trace_id, span_id?}` or `{dataset, version?}`. Kicks off async run; returns `{run_id}`. Emits server-sent progress on `/api/loading/progress` (reuse the existing bus from `internal/serve/progress.go`). |
+| `PUT /api/judges/{name}` | Create / update. Body: judge YAML as JSON. |
+
+Judge runs from the dashboard need API keys. The dashboard uses the same client-side-key model as spec [`#7 playground`](./2026-05-05-playground.md): keys are stored in browser localStorage, sent per-request, and the server holds them only for the request duration. **Server logs never contain keys.** Verify via test.
+
+Cache-Control:
+- `GET /api/judges` → `public, max-age=60`
+- `GET /api/judges/{name}` → `public, max-age=60` (mutable on edit)
+
+## 7. Web UI surface
+
+| File | Role |
+|---|---|
+| `web/src/pages/Judges.tsx` (new) | List judges at `/judges`. New / edit. Editor uses Monaco or shadcn `Textarea` with YAML highlighting (defer Monaco if footprint is too large; spec #6 prompt management likely justifies Monaco regardless — coordinate). |
+| `web/src/pages/JudgeDetail.tsx` (new) | Detail view at `/judges/:name`. Edit YAML; "Run against dataset" picker; score history sparkline. |
+| `web/src/components/JudgeBadge.tsx` (new) | Renders a judge score on a span row in the trace tree (spec #1) when a judge has scored it. Subtle: small numeric badge, tooltip shows reason. |
+| `web/src/components/RunJudgeButton.tsx` (new) | Mounted in `SpanDetail` (spec #1). One-click "score this span with judge X". |
+
+App.tsx routes: `/judges`, `/judges/:name`.
+
+The trace tree from spec #1 needs to know about judge spans so it can show the `JudgeBadge`. Add a span-attribute filter: any span with `gen_ai.evaluation.*` is a judge span. Render judge spans inline with the rest of the tree but visually distinguished (different row icon).
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/eval/inspect/`, `internal/eval/promptfoo/` | Adapter pattern. Copy the structure: a package that wraps a third-party tool, emits OTel, registers an `Adapter` in `internal/runner/adapter.go`. The judge is conceptually similar — a "tool" that runs over outputs. |
+| `internal/runner/exec.go` | Where the OTel pipe-through is set up. The judge runs inside this same pipe so its spans land in the recorded trace. |
+| `internal/persist/persist.go` | Reuse the same clone-mutate-push helpers that suppressions and (per spec #3) datasets use. Add a `WriteJudge(name string, yaml []byte, msg string) error`. |
+| `internal/cli/cli.go`, `wire.go` | Existing kong + DI patterns. Add the `Judge` command. |
+| `internal/runner/python/pytest/` | Existing pytest plugin scaffold. Extend with `defrost.judge(...)`. |
+| `internal/serve/progress.go` | Reuse the SSE bus for async judge run progress in the dashboard. |
+| `web/src/components/SpanDetail.tsx` (spec #1) | Mount `RunJudgeButton` here. |
+
+**New files only:**
+
+- `internal/eval/judge/` — `judge.go`, `load.go`, `score.go`, `score_test.go`, `load_test.go`.
+- `internal/persist/judge.go` (+ `judge_test.go`) — git-write helpers.
+- `internal/serve/judges.go` (+ `judges_test.go`)
+- `internal/cli/judge.go` (+ `judge_test.go`)
+- `internal/runner/python/pytest/judge.py` — Python-side adapter (calls into the Go binary, or directly into the LLM API; see open questions).
+- `web/src/pages/Judges.tsx`, `JudgeDetail.tsx`, plus tests.
+- `web/src/components/JudgeBadge.tsx`, `RunJudgeButton.tsx`, plus tests.
+- Public docs as listed in §3.
+
+## 9. OTel emission
+
+Judge runs emit one span per scoring call:
+
+```text
+span.name        = "defrost.judge.score"
+span.kind        = INTERNAL
+span.attributes  = {
+  "gen_ai.evaluation.judge_name":   <name>,
+  "gen_ai.evaluation.judge_version": <git SHA of YAML>,
+  "gen_ai.evaluation.score":         <float>,
+  "gen_ai.evaluation.label":         <string, optional>,
+  "gen_ai.evaluation.reason":        <string>,
+  "gen_ai.evaluation.target_trace_id": <hex>,
+  "gen_ai.evaluation.target_span_id":  <hex, optional>,
+  "gen_ai.evaluation.input":         <serialized input>,
+  "gen_ai.evaluation.output":        <serialized output>,
+  // standard gen_ai.* for the judge-LLM call itself:
+  "gen_ai.request.model":            <judge model>,
+  "gen_ai.usage.input_tokens":       ...,
+  "gen_ai.usage.output_tokens":      ...,
+  "gen_ai.response.model":           ...,
+}
+span.events      = [...]  // any tool-use events from the judge call
+```
+
+Cost / token columns from spec #2 light up automatically because the same `gen_ai.usage.*` attributes are present.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/eval/judge/score_test.go` | Given a stub `Provider` that returns a known JSON response, `Judge.Score` returns the expected `Score`. Malformed responses (non-JSON, missing keys) → typed errors. Templating: `{{input}}` / `{{output}}` substitution is correct, including with empty strings, with newlines, with quotes. |
+| `internal/eval/judge/load_test.go` | YAML round-trip; missing required fields → typed errors with field paths; unknown fields → warning, not error (forward compat). |
+| `internal/persist/judge_test.go` | `WriteJudge` produces a commit on the data branch with the right path. Concurrent writers retry on non-FF. |
+| `internal/serve/judges_test.go` | All endpoints return expected shapes. POST `/api/judges/{name}/run` accepts both trace-mode and dataset-mode bodies. `Authorization` headers / API keys are not logged (assert via a captured logger). |
+| `internal/cli/judge_test.go` | `judge create` → file exists. `judge run --trace` against a fixture trace produces an OTel span with the expected attributes. `judge run --dataset` invokes once per row. |
+| `web/src/pages/Judges.test.tsx`, `JudgeDetail.test.tsx`, plus the two new components. | Render + fetch + POST flows. |
+
+## 11. Acceptance criteria
+
+- A user can define a judge in YAML, run it against a captured trace from the CLI, and see a span with `gen_ai.evaluation.score` recorded under the same trace pipeline.
+- A user can run the same judge against every row in a dataset; results show up as scored rows in the dataset detail view.
+- The trace tree shows `JudgeBadge` next to spans that have been scored.
+- The dashboard never persists API keys server-side. Verified via test that POSTed keys do not appear in any log line.
+- Pytest users can call `defrost.judge("name").score(...)` and get the same OTel emission as the CLI.
+- Public docs `docs/guides/llm-as-judge.md`, `docs/concepts/evaluators.md`, `docs/reference/cli/judge.md` exist and match the implementation.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+- **Squatting on `gen_ai.evaluation.*`.** This namespace isn't ratified upstream. Recommendation: ship under it, file an OTel SemConv RFC, and migrate to whatever upstream lands. Document the RFC link from the docs page.
+- **Reproducibility.** LLM judges are nondeterministic at `temperature > 0`. Recommendation: default `temperature: 0.0`. Document that scores can vary across re-runs and that defrost stores the raw response for audit.
+- **Score schema scaling.** v1 supports scalar and categorical. What about multi-axis (e.g., `{helpfulness: 4, correctness: 5}`)? Recommendation: defer. When demand surfaces, multi-axis is a YAML schema change + new attribute scheme.
+- **Where does the Python `defrost.judge` impl live?** Two options: (a) shell out to `defrost judge run`, or (b) re-implement the judge in Python. Recommendation: (a) for v1 — keeps the source of truth in Go, avoids drift. Document the perf cost of `exec` per row; fold (b) in only if it becomes a bottleneck.
+- **Caching judge results.** A judge over the same `(input, output, judge SHA)` always returns the same answer at temp=0. Recommendation: don't cache in v1; rerunning is cheap relative to the LLM cost which the user already paid. Cache later if needed.
+- **Score storage on the data branch.** Currently scores live only inside trace files. Should we materialize a flat `judges/<name>/scores.jsonl` for easier diff? Recommendation: no — DuckDB hydration over trace spans is fast enough, and a denormalized file would get out of sync. Reconsider only if `git diff` ergonomics suffer.

--- a/docs/_internal/specs/2026-05-05-monitoring-dashboards.md
+++ b/docs/_internal/specs/2026-05-05-monitoring-dashboards.md
@@ -1,0 +1,136 @@
+# Spec #10 — Monitoring dashboards
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation. Builds on [`#1 trace-tree-ui`](./2026-05-05-trace-tree-ui.md), [`#2 cost-token-surfacing`](./2026-05-05-cost-token-surfacing.md).
+**Phase:** 5 — feedback + observability polish.
+
+## 1. Goal
+
+Time-series production dashboards: latency (p50 / p95 / p99), error rate, throughput, and cost over time. Tiles on the home page; full charts on a dedicated `/monitoring` route. All charts read from existing trace data through the `query.Querier` seam — no new ingestion.
+
+## 2. Why this matters competitively
+
+Both LangSmith and Langfuse ship rich monitoring dashboards as one of their headline marketing screens. Without them, defrost gets "great for tests, weak for prod" feedback — even though the same captured trace data already supports prod monitoring. This spec closes the perception gap.
+
+defrost's angle is honest scale: monitoring queries hit DuckDB on disk, which is fast for ~GB-scale history. Past that, hosted-tier ClickHouse takes over (the `query.Querier` interface was designed for this — see parent spec §7).
+
+## 3. Public docs to write first
+
+- **New page:** `docs/guides/production-monitoring.md` — "Latency, errors, and cost over time." Sections: "What's tracked", "Reading the charts", "Drilling into a spike". Stay neutral.
+- **Edit:** `docs/reference/serve-api.md` — document `/api/timeseries`.
+
+## 4. Storage layout
+
+**No change.** All charts read from existing span data via DuckDB.
+
+## 5. CLI surface
+
+- `defrost monitor [--metric latency|errors|throughput|cost] [--from <date>] [--to <date>] [--interval <bucket>] [--json]` — print a timeseries to stdout. Useful for piping into terminal charting tools or for shell-based alerting in lieu of building alerts into defrost (see §12).
+
+## 6. HTTP API surface
+
+In `internal/serve/timeseries.go`:
+
+`GET /api/timeseries?metric=<name>&from=<RFC3339>&to=<RFC3339>&interval=<bucket>&group_by=<dim>`
+
+Where:
+
+- `metric` is one of: `latency_p50`, `latency_p95`, `latency_p99`, `error_rate`, `throughput`, `cost`.
+- `interval` is `1m`, `5m`, `15m`, `1h`, `6h`, `1d`. Default depends on the from/to range (auto-pick to keep ~100 buckets).
+- `group_by` is optional: `model`, `session.user_id`, `service.name`. When set, returns one series per group.
+
+Response:
+
+```json
+{
+  "metric": "latency_p95",
+  "from": "2026-04-05T00:00:00Z",
+  "to":   "2026-05-05T00:00:00Z",
+  "interval": "1h",
+  "series": [
+    {
+      "key": "anthropic/claude-opus-4-7",
+      "buckets": [
+        { "ts": "2026-04-05T00:00:00Z", "value": 1234.5 }
+      ]
+    }
+  ]
+}
+```
+
+Cache-Control: `public, max-age=60`.
+
+### Querier extension
+
+```go
+type QuerierWithTimeseries interface {
+    Querier
+    Timeseries(req TimeseriesRequest) (TimeseriesResult, error)
+}
+```
+
+Implementation in `internal/query/duckdb/timeseries.go`. SQL over span durations and statuses with time-bucketing. `latency_p95` uses DuckDB's `quantile_disc(...)`.
+
+## 7. Web UI surface
+
+| File | Role |
+|---|---|
+| `web/src/pages/Monitoring.tsx` (new) | `/monitoring`. Multiple charts (latency, errors, throughput, cost) with shared time-range picker. |
+| `web/src/components/TimeseriesChart.tsx` (new) | Generic line / area chart wrapper. Reuses recharts via shadcn `<Chart>`. |
+| `web/src/components/TimeRangePicker.tsx` (new) | Shared date-range control (last 1h / 24h / 7d / 30d / custom). |
+| `web/src/pages/Home.tsx` (or wherever the heatmap lives) | Add 4 sparkline tiles above the heatmap (latency p95, error rate, throughput, cost). |
+
+Auto-refresh: tiles refetch every 60s when the page is visible. Use TanStack Query's `refetchInterval`.
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/query/duckdb/` | Add `timeseries.go`. Reuse the existing span / metric tables. |
+| `internal/serve/server.go` | Wire endpoint; impl in `internal/serve/timeseries.go`. |
+| `internal/cost/compute.go` (spec #2) | Compute cost when the metric is `cost`. |
+| `web/src/components/DurationSparkline.tsx` (existing) | Pattern to copy for `TimeseriesChart`. |
+| `web/src/components/CostChart.tsx` (spec #2) | Reuse for the `/monitoring` cost panel. |
+| `web/src/queryClient.ts` | Existing TanStack Query config; reuse. |
+
+**New files only:**
+
+- `internal/query/duckdb/timeseries.go` (+ test)
+- `internal/serve/timeseries.go` (+ test)
+- `internal/cli/monitor.go` (+ test)
+- `web/src/pages/Monitoring.tsx` (+ test)
+- `web/src/components/TimeseriesChart.tsx`, `TimeRangePicker.tsx` plus tests.
+- `docs/guides/production-monitoring.md`
+
+## 9. OTel emission
+
+This feature is read-only. No telemetry emitted.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/query/duckdb/timeseries_test.go` | Given a fixture with N traces over a known time range, all six metrics produce the expected buckets. `interval` auto-selection picks reasonable values. `group_by` produces multiple series. |
+| `internal/serve/timeseries_test.go` | Endpoint shape correct; bad params (unknown metric, invalid date) → 400 with clear error. |
+| `internal/cli/monitor_test.go` | Default metric is `latency_p95`. `--json` output is parseable. |
+| `web/src/components/TimeseriesChart.test.tsx`, `TimeRangePicker.test.tsx` | Rendering + interaction. |
+| `web/src/pages/Monitoring.test.tsx` | Multiple charts render; auto-refetch fires when interval elapses. |
+
+## 11. Acceptance criteria
+
+- The home page shows four sparkline tiles (latency p95, error rate, throughput, cost) for the last 24h.
+- `/monitoring` shows the four charts with a shared time-range picker (1h / 24h / 7d / 30d / custom).
+- Charts auto-refresh every 60s while visible; pause when the tab is backgrounded.
+- `defrost monitor --metric latency_p95 --from <date> --to <date> --json` emits a stable JSON shape suitable for piping into shell-based alerting.
+- All charts populated correctly from existing trace data — no new data sources required.
+- Public docs at `docs/guides/production-monitoring.md` exist.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+- **Alerting.** Out of scope for v1. Recommendation: explicitly defer. The CLI's `--json` output is the official integration point — users wire it into their existing alerting (Prometheus alertmanager, PagerDuty, etc.). This keeps defrost from reinventing alert routing.
+- **Custom metrics.** Some users will want to chart `gen_ai.usage.input_tokens` directly, or a custom span attribute. Recommendation: ship the six fixed metrics in v1; add a `metric=custom&attribute=<name>&aggregation=<sum|avg|p95>` mode in a follow-up if demand surfaces.
+- **Group-by cardinality blowup.** Grouping by `session.user_id` over a 30-day window can produce thousands of series. Recommendation: cap series count at 50 by default with a "show top N by total" rollup; flag in docs.
+- **DuckDB query performance at scale.** A 1d window over 100k traces should be sub-second; 1y over 10M traces will not be. Recommendation: document the comfort zone in the new guide. When users exceed it, that's the hosted-tier conversation.
+- **Time-zone handling.** Recommendation: API in UTC, dashboard renders in browser local time. Document the convention.

--- a/docs/_internal/specs/2026-05-05-pairwise-comparison.md
+++ b/docs/_internal/specs/2026-05-05-pairwise-comparison.md
@@ -1,0 +1,139 @@
+# Spec #5 — Pairwise comparison view
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation. Depends on [`#1 trace-tree-ui`](./2026-05-05-trace-tree-ui.md), [`#2 cost-token-surfacing`](./2026-05-05-cost-token-surfacing.md), [`#4 llm-as-judge`](./2026-05-05-llm-as-judge.md).
+**Phase:** 3 — evals as first-class.
+
+## 1. Goal
+
+A side-by-side view of two runs (A vs B) — comparing prompts, models, or commits — at `/compare/:a/:b`. Two trace trees rendered in parallel with aligned spans highlighted, divergent spans flagged, and a summary header showing Δ cost, Δ latency, and Δ judge score.
+
+## 2. Why this matters competitively
+
+Pairwise comparison is the screen developers open when evaluating "did the new prompt help?" — the exact question both LangSmith and Langfuse pitch their product on. Without it, any A/B claim about a prompt or model swap requires the user to flip between two browser tabs and eyeball the difference.
+
+defrost's structural advantage: **comparing two runs is `git diff` of two trace files.** Once we render it well, this is also the screen that makes "PR-diffable evals" tangible — a CI bot can post `/compare/<main-run>/<feature-run>` URLs as PR comments.
+
+## 3. Public docs to write first
+
+- **New page:** `docs/guides/comparing-runs.md` — "A/B two runs side-by-side." Sections: "Open the comparison view", "Read the alignment", "Δ cost / latency / score", "Linking comparisons in PR comments".
+- **Edit:** `docs/reference/serve-api.md` — document `/api/runs/compare`.
+- **Edit:** `docs/guides/inspecting-a-trace.md` (from spec #1) — link to the new comparison page.
+
+## 4. Storage layout
+
+**No change.** Comparison is purely a read-side view over two existing trace files.
+
+## 5. CLI surface
+
+One new command, optional but useful for CI / scripting:
+
+- `defrost compare <run-a> <run-b> [--json]` — print a comparison summary (Δ cost, Δ latency, Δ judge score, # aligned vs unaligned spans). `--json` for machine consumption (e.g., a PR-comment bot).
+
+The command is sugar over `GET /api/runs/compare`. Same data, no new logic.
+
+## 6. HTTP API surface
+
+In `internal/serve/compare.go`:
+
+`GET /api/runs/compare?a=<run-id>&b=<run-id>`:
+
+```json
+{
+  "a": { "run_id": "...", "trace_id": "...", "commit": "...", "branch": "...", "ts": "..." },
+  "b": { ...same shape... },
+  "summary": {
+    "delta_cost_usd": -0.018,
+    "delta_latency_ms": +120,
+    "delta_judge_scores": {
+      "helpfulness-v1": +0.4,
+      "correctness-v1": -0.1
+    },
+    "spans_aligned": 18,
+    "spans_only_in_a": 2,
+    "spans_only_in_b": 1
+  },
+  "alignment": [
+    { "kind": "match", "a_span_id": "...", "b_span_id": "...", "key": "<input-hash>" },
+    { "kind": "only_a", "a_span_id": "..." },
+    { "kind": "only_b", "b_span_id": "..." }
+  ]
+}
+```
+
+**Cache-Control:** `public, max-age=86400` (the pair is immutable once both runs are persisted).
+
+### Alignment algorithm
+
+In `internal/serve/compare.go` (or `internal/compare/` if richer logic justifies its own package):
+
+1. Load both trace trees via `query.QuerierWithTraceTree.LookupTrace` (spec #1).
+2. Compute an alignment key for each span: `sha256(span.name + canonical_json(input_attr))[:16]` where `input_attr` is the first present of `gen_ai.request.input`, `gen_ai.prompt`, `gen_ai.input.messages`. Spans without LLM-input attributes use `sha256(span.name + parent_alignment_key)`.
+3. Match A→B greedily by alignment key, breaking ties by depth-first order. Unmatched spans become `only_a` / `only_b`.
+4. Compute deltas from already-projected attributes (cost from spec #2, judge scores from spec #4).
+
+This is intentionally simple. When trace structures are very different, expect many unaligned spans. The UI surfaces this honestly rather than fabricating false matches.
+
+## 7. Web UI surface
+
+| File | Role |
+|---|---|
+| `web/src/pages/Compare.tsx` (new) | Route `/compare/:a/:b`. Renders summary header + two `TraceTree` instances side-by-side. |
+| `web/src/components/CompareSummary.tsx` (new) | Header card. Shows Δ cost, Δ latency, Δ judge score, alignment stats. Color: green for "B is better", red for "B is worse" — heuristic per metric (lower cost = better, lower latency = better, higher judge score = better). |
+| `web/src/components/TraceTree.tsx` (extended from spec #1) | Accept an optional `alignment` prop. When provided, color-code rows: matched (default), only-this-side (highlighted), and on hover in pane A, scroll to matched row in pane B. |
+
+App.tsx route: `/compare/:a/:b`.
+
+UX: deep-linkable URL. The "Compare with…" button on `RunDetailSheet` opens a picker (most recent N runs by default; search by commit SHA / branch). Picking one navigates to `/compare/<current>/<picked>`.
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/query/duckdb/` (spec #1's `LookupTrace`) | Two calls per comparison. No new query method. |
+| `internal/serve/server.go` | Wire the new endpoint. Implementation in `internal/serve/compare.go`. |
+| `internal/cost/compute.go` (spec #2) | Sum cost per side. |
+| `web/src/components/TraceTree.tsx`, `SpanDetail.tsx` (spec #1) | Reuse directly. |
+| `web/src/components/RunDetailSheet.tsx` | Add "Compare with…" button. |
+
+**New files only:**
+
+- `internal/serve/compare.go` (+ `compare_test.go`)
+- `internal/compare/` (only if alignment logic grows beyond ~150 lines — start in `internal/serve/compare.go` and split if it bloats)
+- `internal/cli/compare.go` (+ `compare_test.go`)
+- `web/src/pages/Compare.tsx` (+ test)
+- `web/src/components/CompareSummary.tsx` (+ test)
+- `docs/guides/comparing-runs.md`
+
+## 9. OTel emission
+
+This feature is read-only. No telemetry emitted.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/serve/compare_test.go` | Given two fixture traces with overlapping and divergent spans, `/api/runs/compare` returns the expected `summary` and `alignment`. Edge case: identical traces → all matched, deltas zero. Edge case: completely disjoint traces → all unaligned. Cache-Control set. |
+| `internal/cli/compare_test.go` | `defrost compare a b` prints the human summary; `--json` prints exact JSON shape. |
+| `web/src/pages/Compare.test.tsx` | Renders both tree panes; summary card shows correct deltas; matched-row hover triggers paired scroll (jsdom limitation: assert handler called rather than visual scroll). |
+| `web/src/components/CompareSummary.test.tsx` | Color heuristics correct. Missing scores rendered as `—`, not zero. |
+| `web/src/components/TraceTree.test.tsx` (extended from spec #1) | Alignment prop colors rows correctly. |
+
+## 11. Acceptance criteria
+
+- A user with two captured runs can navigate to `/compare/<a>/<b>` and see both trace trees side-by-side with aligned spans visually paired.
+- The summary header shows Δ cost (USD), Δ latency (ms), and one Δ row per judge that scored both runs.
+- `defrost compare a b --json` produces a stable, scriptable output suitable for a CI PR-comment bot.
+- The "Compare with…" button on a run-detail panel offers a picker; picking navigates to the comparison page.
+- Completely disjoint traces render correctly (no false matches), with the alignment stats reporting them as unaligned.
+- Public docs `docs/guides/comparing-runs.md` exists. Links from the trace-tree guide work.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+- **Alignment heuristic when trace structures differ a lot.** Recommendation: ship the simple input-hash heuristic in v1; it correctly handles the most common case (same dataset row, different model). Surface alignment-stats prominently so users know when they're looking at high-divergence pairs.
+- **Three-way comparison.** `/compare/a/b/c`? Recommendation: defer. Demand pull this when it lands.
+- **PR-comment bot.** Out of scope for this spec, but the JSON shape from `--json` is designed so a follow-up GitHub Action can post `/compare/<base-run>/<head-run>` links. Spec the action separately.
+- **Aggregate dataset comparison.** "Compare A vs B over an entire dataset" is genuinely useful but requires aggregating across N row-pairs. Recommendation: spec separately. This spec covers single-run pairs only.
+- **What if both run IDs hash to traces on different commits with different code paths?** That's the point — the comparison is honest about divergence. Don't try to "fix" it.

--- a/docs/_internal/specs/2026-05-05-playground.md
+++ b/docs/_internal/specs/2026-05-05-playground.md
@@ -1,0 +1,205 @@
+# Spec #7 — Interactive playground
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation. Depends on [`#6 prompt-management`](./2026-05-05-prompt-management.md), [`#1 trace-tree-ui`](./2026-05-05-trace-tree-ui.md).
+**Phase:** 4 — prompts + playground.
+
+## 1. Goal
+
+An interactive UI inside `defrost serve` for editing prompts, swapping models, and comparing outputs side-by-side. Critical positioning constraint: **API keys are never persisted server-side.** Keys live only in browser localStorage and travel with each request to the server-side proxy. Each playground run is captured by the same OTel pipeline as everything else, so it appears in the heatmap and the trace tree without any extra step.
+
+## 2. Why this matters competitively
+
+Both LangSmith and Langfuse ship a playground. It's table stakes for the four-feature Tier-S surface. defrost's differentiator is positioning, not novelty: **we never store your API keys.** Self-host LLM observability shouldn't ask users to hand secrets to yet-another-service. Every key in the wire is the user's; defrost is a thin proxy that emits telemetry and forgets the key as soon as the response returns.
+
+This is also a marketing surface: "defrost playground — your keys never touch our disk" is a one-line pitch even non-technical reviewers grok.
+
+## 3. Public docs to write first
+
+- **New page:** `docs/guides/playground.md` — "Try a prompt without writing code." Sections: "Open the playground", "Bring your API key", "Multi-model comparison", "Pin a result to a dataset". Make the keys-stay-in-the-browser story explicit.
+- **Edit:** `docs/concepts/git-as-database.md` or a new `docs/concepts/api-keys.md` — short page on the no-server-side-key-storage policy.
+- **Edit:** `docs/reference/serve-api.md` — document `/api/playground/run`.
+
+## 4. Storage layout
+
+**No new persistent storage on the data branch.** Playground runs flow through the standard OTel pipeline (`internal/otlp/`) and land as normal trace files. The user can identify playground runs by a resource attribute `defrost.run.source = "playground"` on the root span.
+
+Server-side, the key handling rule is strict:
+
+- The HTTP request body carries the key.
+- Server holds the key in memory only for the duration of the LLM call.
+- **Logs never contain the key.** Verified by test (see §10).
+- The key is **not** written to disk. **Not** passed to subprocesses.
+
+## 5. CLI surface
+
+**No new CLI commands.** The playground is a dashboard concern. CLI users have `defrost exec` for the same outcome.
+
+## 6. HTTP API surface
+
+In `internal/serve/playground.go`:
+
+### `POST /api/playground/run`
+
+Request body:
+
+```json
+{
+  "prompt_name": "support/welcome",        // or use prompt_text directly
+  "prompt_ref":  "production",             // optional, defaults to HEAD
+  "prompt_text": "...",                    // alternative to prompt_name+ref
+  "model":       "anthropic/claude-opus-4-7",
+  "temperature": 0.2,
+  "max_tokens":  512,
+  "input":       { "user_name": "Alice", "intent": "billing" },
+  "api_key":     "sk-...",                 // sent per-request, never stored
+  "stream":      true
+}
+```
+
+Response: streaming Server-Sent Events.
+
+```
+event: token
+data: {"text": "Hello"}
+
+event: token
+data: {"text": ", Alice"}
+
+event: done
+data: {"trace_id": "...", "tokens_in": 23, "tokens_out": 12, "cost_usd": 0.0006}
+```
+
+### `POST /api/playground/compare`
+
+Same as `/run` but accepts `models: [...]` and emits parallel streams (one event per model). Useful for the side-by-side view.
+
+### `GET /api/playground/providers`
+
+Returns the static list of supported providers + models that defrost knows how to proxy to.
+
+```json
+{
+  "providers": [
+    { "id": "anthropic", "models": ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"] },
+    { "id": "openai", "models": ["gpt-5", "gpt-5-mini"] },
+    { "id": "google", "models": ["gemini-2.5-pro", "gemini-2.5-flash"] },
+    { "id": "openrouter", "models": ["*"] }
+  ]
+}
+```
+
+### Provider proxy implementation
+
+In `internal/playground/`:
+
+- `provider.go` — `type Provider interface { Stream(ctx, req) (<-chan Token, error) }`
+- `anthropic.go`, `openai.go`, `google.go`, `openrouter.go` — one impl per provider. Direct HTTP calls to the provider's API; do not pull in heavy SDKs.
+- `proxy.go` — request-scoped struct that owns the key for the duration of one call.
+
+Each provider impl:
+
+1. Receives `(req, key)`.
+2. Builds the upstream request with the user's key.
+3. Streams the response back as `Token` channel events.
+4. Emits OTel spans with full `gen_ai.*` attributes.
+5. Drops the key from memory on return.
+
+**Logging discipline:** `internal/playground/proxy.go` uses a custom logger wrapper that scrubs any field whose key contains `key`, `token`, `secret`, or `authorization`. Every test in this package asserts no upstream-key value appears in captured log output.
+
+## 7. Web UI surface
+
+| File | Role |
+|---|---|
+| `web/src/pages/Playground.tsx` (new) | Route `/playground`. Three-pane layout. |
+| `web/src/components/PromptPane.tsx` (new) | Left pane. Prompt editor (reuses `PromptEditor` from spec #6 if present, or a minimal Monaco-backed editor). Optional: pick an existing prompt from the registry. |
+| `web/src/components/ModelControls.tsx` (new) | Middle pane. Model picker (from `/api/playground/providers`), temperature, max-tokens, and an input form derived from the prompt's `input_schema`. |
+| `web/src/components/OutputPane.tsx` (new) | Right pane. Streams output from `POST /api/playground/run`. Multi-model mode shows N output panels side-by-side. |
+| `web/src/components/ApiKeyInput.tsx` (new) | Modal / drawer. Lists configured keys (one per provider), stored in `localStorage`. Toggle "remember key on this device" — if off, keys clear on tab close (`sessionStorage`). |
+| `web/src/lib/secrets.ts` (new) | Storage abstraction. Never logs values. |
+
+App.tsx route: `/playground`.
+
+### Capture-to-dataset
+
+A "Pin to dataset" button on the output pane opens a modal (reuses `AddToDatasetButton` from spec #3). Pins the `(input, output)` pair as a row in the chosen dataset.
+
+### "Open in playground" affordance
+
+On any LLM span in the trace tree (spec #1), an "Open in playground" button pre-fills the playground with that span's prompt and input. Reproduces and modifies a prior call in two clicks.
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/otlp/sink.go` | Existing OTel span emission. Playground spans flow through here unchanged. |
+| `internal/runner/runtime.go` | Existing OTLP env var setup. Playground runs **don't** spawn a subprocess, so this isn't needed; the proxy emits spans directly via the in-process OTel SDK. |
+| `internal/serve/server.go` | Wire new endpoints; impls in `internal/serve/playground.go` and `internal/playground/`. |
+| `internal/prompt/client.go` (spec #6) | Resolve `prompt_name + prompt_ref` to body + frontmatter. |
+| `internal/cost/compute.go` (spec #2) | Compute cost from token counts. |
+| `web/src/components/AddToDatasetButton.tsx` (spec #3) | Reuse for the "Pin to dataset" button. |
+| `web/src/components/PromptEditor.tsx` (spec #6, if shipped) | Reuse for the prompt pane. |
+
+**New files only:**
+
+- `internal/playground/` — `playground.go`, `provider.go`, `anthropic.go`, `openai.go`, `google.go`, `openrouter.go`, `proxy.go`, plus `*_test.go`.
+- `internal/serve/playground.go` (+ test)
+- `web/src/pages/Playground.tsx` (+ test)
+- `web/src/components/PromptPane.tsx`, `ModelControls.tsx`, `OutputPane.tsx`, `ApiKeyInput.tsx` plus tests.
+- `web/src/lib/secrets.ts` (+ test)
+- `docs/guides/playground.md`
+
+## 9. OTel emission
+
+Each playground call emits one parent span and provider-specific child spans:
+
+```text
+parent span:
+  name        = "defrost.playground.run"
+  attributes  = {
+    "defrost.run.source":     "playground",
+    "defrost.prompt.name":    <name-or-empty>,
+    "defrost.prompt.ref":     <resolved-sha-or-empty>,
+    "gen_ai.request.model":   <model>,
+    "gen_ai.request.temperature": <float>,
+    "gen_ai.request.max_tokens":  <int>,
+  }
+
+child span:
+  name        = "gen_ai.client.chat"
+  attributes  = standard gen_ai.* + provider-specific
+```
+
+This makes playground runs first-class in the trace tree, the cost chart, and any judge that scores them.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/playground/anthropic_test.go` (and analogues) | Stub the upstream HTTP transport (`httptest.Server`); assert request shape, response streaming, error handling (429, 5xx). The user's API key never appears in captured server logs. |
+| `internal/playground/proxy_test.go` | The key in the request never reaches the OTel span attribute. Logger scrubbing is correct (test with strings containing "key", "token", etc.). |
+| `internal/serve/playground_test.go` | `/api/playground/run` end-to-end with a stub provider; emits SSE in the expected order; the response-final event includes `trace_id`, `tokens_in`, `tokens_out`, `cost_usd`. The persisted trace file (verify against the test fixture data branch) contains a span with `defrost.run.source = "playground"`. |
+| `web/src/pages/Playground.test.tsx` | Three-pane layout renders. Picking a prompt + model + filling input + clicking "Run" issues the expected POST. SSE chunks render incrementally. |
+| `web/src/lib/secrets.test.ts` | localStorage / sessionStorage round-trip; no value ever logged via console. |
+| `web/src/components/ApiKeyInput.test.tsx` | "Remember key" toggle controls localStorage vs sessionStorage. |
+
+## 11. Acceptance criteria
+
+- A user can paste an API key, edit a prompt, and run it against any supported model from `/playground`.
+- Multi-model comparison shows N outputs streaming in parallel.
+- Each run shows up in the heatmap and at `/trace/<trace-id>` automatically.
+- The user's API key is **never** written to defrost's logs, never persisted to disk on the server, and never passed to a subprocess.
+- "Pin to dataset" captures the run as a dataset row.
+- "Open in playground" from a span in the trace tree pre-fills with the right inputs.
+- Public docs at `docs/guides/playground.md` exist and explicitly state the no-server-side-key policy.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+- **Streaming proxy buffering.** Large outputs need flow control to avoid head-of-line blocking. Recommendation: stream in 64-byte chunks (or whatever the provider sends). Don't buffer.
+- **Rate limit / 429 handling.** Recommendation: surface the upstream 429 status to the UI verbatim; don't retry in v1. Document that the user's account is the rate-limit subject, not defrost.
+- **Provider auth other than bearer tokens.** Some providers (e.g., AWS Bedrock) use signed requests. Recommendation: defer Bedrock-style auth to a follow-up. v1 covers bearer-token providers (Anthropic, OpenAI, Google, OpenRouter).
+- **Local model providers (ollama, llama.cpp, vLLM).** Recommendation: add as a v1 provider — it's a simple HTTP proxy and the "no API key needed" path is even simpler. Add `localhost` to the providers list. This is a cheap additional differentiator vs Langfuse, which assumes cloud LLMs.
+- **Where does the key actually live in memory?** Recommendation: pass through function args, never assign to a struct field with a long lifetime. Add a unit test that uses Go's `runtime.GC` + `runtime.SetFinalizer` to assert keys are GC'd promptly. (May be over-engineered; flag and revisit.)
+- **CSRF on `/api/playground/run`.** `defrost serve` binds to `127.0.0.1` only, so CSRF is moot. Document the assumption. If a future hosted tier exposes the same endpoint over the open Internet, CSRF protection becomes mandatory.

--- a/docs/_internal/specs/2026-05-05-prompt-management.md
+++ b/docs/_internal/specs/2026-05-05-prompt-management.md
@@ -1,0 +1,214 @@
+# Spec #6 — Prompt management
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation.
+**Phase:** 4 — prompts + playground.
+
+## 1. Goal
+
+Versioned prompt registry. Prompts are Markdown files with YAML frontmatter, stored on the data branch under `prompts/`. Versioning is git history of the file — no separate registry service. Apps fetch prompts via a Go library or HTTP API; pinning to a label (e.g. `production`) is a git tag.
+
+A user can:
+
+1. Create / edit a prompt in the dashboard or via CLI.
+2. Read the prompt at HEAD or at any past ref.
+3. Move a label (e.g., `production`) to a new version atomically.
+4. Diff two prompt versions visually.
+5. From their app, call `defrost.GetPrompt("name", "production")` and get atomic, cached updates.
+
+## 2. Why this matters competitively
+
+Prompt management is half of LangSmith's "Prompt Hub" pitch (the other half being the playground — spec [`#7`](./2026-05-05-playground.md)). Langfuse ships server-side caching for low-latency prompt fetches. Without prompt management, defrost is missing one of the four Tier-S features.
+
+defrost's angle: **prompts are files in git.** Versioning, blame, history, branching, code review all come for free. Apps consuming prompts get atomic updates by moving a label — the same mechanism teams already understand. Public-cloud incumbents reinvent this with a custom registry; we just use git.
+
+## 3. Public docs to write first
+
+- **New page:** `docs/guides/managing-prompts.md` — "Version your prompts in git." Sections: "Create a prompt", "Reference from your app", "Pin a label", "Diff two versions", "Roll back".
+- **New page:** `docs/reference/cli/prompt.md` — full CLI reference.
+- **New concept page:** `docs/concepts/prompts.md` — short page on why prompts live on the data branch alongside everything else. Cite `docs/concepts/git-as-database.md`.
+- **Edit:** `docs/reference/storage-layout.md` — add `prompts/` to the directory tree.
+- **Edit:** `docs/reference/serve-api.md` — document new endpoints.
+
+## 4. Storage layout
+
+On the data branch:
+
+```text
+<repo>/.defrost/prompts/
+└── <name>.md
+```
+
+`<name>` matches the dataset/judge charset: `[a-z0-9_/-]+`. Slashes are allowed for namespacing (e.g. `support/welcome.md`); the path is taken literally relative to `prompts/`.
+
+### File format
+
+```markdown
+---
+schema: 1
+description: Customer-support welcome message
+model: anthropic/claude-opus-4-7
+temperature: 0.2
+max_tokens: 512
+input_schema:
+  type: object
+  properties:
+    user_name: { type: string }
+    intent:    { type: string }
+labels:
+  production: 8a3f2b1c   # short SHA on data branch — the pinned ref
+  staging:    9d4e8f7a
+---
+
+You are a friendly customer support agent for Acme Corp.
+
+User: {{ user_name }}
+Detected intent: {{ intent }}
+
+Greet the user, acknowledge their intent, and offer next steps...
+```
+
+The body is the prompt text. Templating uses `{{ var }}` (mustache-compatible — pick a tiny Go templating library; `text/template` works but breaks on `{{`/`}}` collisions in the prompt itself, so prefer `cbroglie/mustache` or similar).
+
+`labels:` is a frontmatter table mapping label name → git short SHA (or full SHA) on the data branch. Moving a label is a re-write of this section + a commit. Discussed in §12.
+
+### Versioning model
+
+Versions are git commits on the data branch. There's no `versions/v1.md` directory — just file history. `defrost prompt show <name>` reads HEAD by default; `--ref <sha-or-label>` reads any past version.
+
+### Atomic write & conflict handling
+
+Same model as suppressions / datasets / judges. Use `internal/persist/persist.go` clone-mutate-push helpers; retry on non-FF.
+
+## 5. CLI surface
+
+`defrost prompt` parent command. Subcommands:
+
+### `defrost prompt create <name> [--from <file>]`
+
+Write a new `prompts/<name>.md` with default frontmatter and (if provided) body from `<file>`. Open `$EDITOR` if `--from` is omitted.
+
+### `defrost prompt edit <name>`
+
+Open `$EDITOR` on `prompts/<name>.md`. Validate frontmatter on save; reject commit if invalid.
+
+### `defrost prompt show <name> [--ref <sha-or-label>] [--body-only] [--json]`
+
+Print the prompt at HEAD or specified ref. `--body-only` prints just the prompt text. `--json` returns `{frontmatter, body}` as JSON.
+
+### `defrost prompt list [--json]`
+
+Print all prompts: `<name>\t<labels>\t<updated-at>`.
+
+### `defrost prompt diff <name> [<ref-a>] [<ref-b>]`
+
+Sugar for `git diff <ref-a> <ref-b> -- prompts/<name>.md` on the data branch. With one arg, diffs HEAD against `<ref-a>`. With no args, diffs HEAD against `HEAD~1`.
+
+### `defrost prompt label <name> <label> [<ref>]`
+
+Move a label to a ref (default: HEAD). Re-writes the prompt's `labels:` frontmatter and commits with message `prompt(<name>): label <label> -> <ref>`. The label re-write is itself a new commit, which means a label history exists naturally in the file's git log. Use a label name `production` consistently to keep app code stable.
+
+### `defrost prompt unlabel <name> <label>`
+
+Remove a label from the file's frontmatter.
+
+## 6. HTTP API surface
+
+In `internal/serve/prompts.go`:
+
+| Method + path | Returns |
+|---|---|
+| `GET /api/prompts` | `{prompts: [{name, labels, updated_at}]}` |
+| `GET /api/prompts/{name}?ref=<sha-or-label>` | `{name, frontmatter: {...}, body: "..."}` |
+| `GET /api/prompts/{name}/history` | `[{sha, ts, author, message, label?}]` — git log of this file |
+| `GET /api/prompts/{name}/diff?from=<ref>&to=<ref>` | Unified diff text or structured per-line diff |
+| `PUT /api/prompts/{name}` | Body: `{frontmatter, body}`. Writes a new commit. |
+| `POST /api/prompts/{name}/labels/{label}` | Body: `{ref}`. Moves the label. |
+| `DELETE /api/prompts/{name}/labels/{label}` | Removes the label. |
+
+Cache-Control:
+
+- `GET /api/prompts` → `public, max-age=60`.
+- `GET /api/prompts/{name}?ref=<full-sha>` → `public, max-age=86400` (immutable when `ref` is a full SHA).
+- `GET /api/prompts/{name}?ref=<label>` → `public, max-age=10` (label can move).
+- `GET /api/prompts/{name}` (no ref, defaulting to HEAD) → `public, max-age=10`.
+- All writes → no cache.
+
+## 7. Web UI surface
+
+| File | Role |
+|---|---|
+| `web/src/pages/Prompts.tsx` (new) | List view at `/prompts`. Table of prompts with active labels and last-updated. New / search. |
+| `web/src/pages/PromptDetail.tsx` (new) | Detail view at `/prompts/:name`. Tabs: "Edit", "History", "Diff". |
+| `web/src/components/PromptEditor.tsx` (new) | Monaco-based editor split into frontmatter (YAML) and body (Markdown). Validates on save. Cmd+S writes via PUT. |
+| `web/src/components/PromptDiffView.tsx` (new) | Side-by-side diff of two refs. Reuses `react-diff-view` or similar. |
+| `web/src/components/LabelChip.tsx` (new) | Small chip showing a label name + ref. Click to open a "move label" modal. |
+
+App.tsx routes: `/prompts`, `/prompts/:name`.
+
+Monaco may not already be in the bundle. If not, this spec introduces the dependency. Coordinate with spec [`#4 llm-as-judge`](./2026-05-05-llm-as-judge.md) which also wants a YAML editor — pick a single editor library and reuse.
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/persist/persist.go` | Clone-mutate-push pattern. Add `WritePrompt(name string, frontmatter PromptMeta, body []byte, msg string) error` and `ReadPrompt(name, ref string) (PromptMeta, []byte, error)`. |
+| `internal/cli/cli.go`, `wire.go` | Add `Prompt` command. |
+| `internal/serve/server.go` | Wire new endpoints; impl in `internal/serve/prompts.go`. |
+| `internal/runner/runtime.go` | If we want `defrost exec` to inject `DEFROST_PROMPT_<NAME>` env vars, hook here. **Defer to a follow-up spec.** v1 keeps prompt access via the library / API only. |
+
+**New files only:**
+
+- `internal/prompt/` — `prompt.go`, `frontmatter.go`, `template.go`, `client.go`, plus tests. The `client.go` exposes `GetPrompt(name, label) (Prompt, error)` for app-side consumption with an in-memory TTL cache.
+- `internal/persist/prompt.go` (+ test)
+- `internal/serve/prompts.go` (+ test)
+- `internal/cli/prompt.go` (+ test)
+- `web/src/pages/Prompts.tsx`, `PromptDetail.tsx` plus tests.
+- `web/src/components/PromptEditor.tsx`, `PromptDiffView.tsx`, `LabelChip.tsx` plus tests.
+
+## 9. OTel emission
+
+Library callers (`defrost.GetPrompt(...)`) emit a span:
+
+```text
+span.name        = "defrost.prompt.get"
+span.attributes  = {
+  "defrost.prompt.name":  <name>,
+  "defrost.prompt.label": <label-or-empty>,
+  "defrost.prompt.ref":   <resolved-sha>,
+  "defrost.prompt.cache_hit": <bool>,
+}
+```
+
+This makes prompt-fetch observability automatic for any app using the library; cache hit-rate becomes visible in the trace tree.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/prompt/frontmatter_test.go` | YAML parse round-trip; missing required fields error; templating substitution with various inputs. |
+| `internal/prompt/client_test.go` | `GetPrompt` cache TTL behaviour: hits cache within TTL, misses after. Concurrent callers don't double-fetch (singleflight). |
+| `internal/persist/prompt_test.go` | Write/read round-trip; label move produces the expected commit; concurrent writers retry. |
+| `internal/serve/prompts_test.go` | All endpoints. `Cache-Control` correct per ref type (full SHA vs label vs HEAD). |
+| `internal/cli/prompt_test.go` | `create` / `show --ref` / `label` / `diff` end-to-end against a temp repo. |
+| `web/src/pages/Prompts.test.tsx`, `PromptDetail.test.tsx` and component tests. | Render + edit + label-move flows. |
+
+## 11. Acceptance criteria
+
+- A user can create, edit, and version a prompt entirely from the dashboard.
+- A user can move a `production` label and have all running apps pick up the new version within TTL (default 60s).
+- An app calling `defrost.GetPrompt("welcome", "production")` gets the body and frontmatter, with templating support.
+- The library emits OTel spans for each fetch; cache hit-rate is visible in the trace tree.
+- `git diff main..feature -- .defrost/prompts/` shows exactly which prompts changed in a PR.
+- Public docs at `docs/guides/managing-prompts.md`, `docs/concepts/prompts.md`, `docs/reference/cli/prompt.md` exist and match the implementation.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+- **Where do labels live — frontmatter or git tags?** Recommendation: **frontmatter.** Git tags are repo-scoped and would collide across N prompts; frontmatter labels are file-scoped naturally. Document the trade-off: tag pushes happen separately from commit pushes, so label updates are atomic with file changes.
+- **Templating library.** `text/template` collides with prompt syntax. Recommendation: `cbroglie/mustache` — small, well-maintained, no collision. Document the dependency clearly.
+- **Caching strategy.** Default TTL 60s, configurable via `defrost.NewPromptClient(opts)`. Recommendation: in-memory TTL + singleflight. Skip Redis-style externally-shared cache; that's hosted-tier territory.
+- **Prompt deletion.** Recommendation: support `defrost prompt delete <name>` only with a `--force` flag. The data is recoverable from git, so deletion is an operational nicety, not a destructive op.
+- **Multiple prompts per file (e.g., system + user prompts).** Recommendation: keep it one prompt per file. If users need a system+user pairing, name them with a shared prefix (`support/welcome.system.md`, `support/welcome.user.md`).
+- **Sharing prompts across repos.** Hosted-tier territory. Don't try to solve.

--- a/docs/_internal/specs/2026-05-05-sessions-users.md
+++ b/docs/_internal/specs/2026-05-05-sessions-users.md
@@ -1,0 +1,132 @@
+# Spec #9 — Sessions & users grouping
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation. Depends on [`#1 trace-tree-ui`](./2026-05-05-trace-tree-ui.md).
+**Phase:** 5 — feedback + observability polish.
+
+## 1. Goal
+
+Group traces by `session.id` and `user.id`. Both are existing OTel resource attributes that defrost already captures (no schema change needed). This spec is pure UI surfacing: list sessions, view a session timeline, view a user's trace history, filter the heatmap by session or user.
+
+## 2. Why this matters competitively
+
+LangSmith and Langfuse both ship "Sessions" and "Users" as named features. They're surface UI on top of OTel attributes that any well-instrumented app already emits. Without these views, defrost users have no way to ask "what was Alice doing yesterday?" or "what's the conversation history of session X?" — even though the data is right there.
+
+This is one of the cheapest wins in the spec batch: no new ingestion, no new storage, just new query patterns and new pages.
+
+## 3. Public docs to write first
+
+- **New page:** `docs/guides/sessions-and-users.md` — "Group traces by session or user." Sections: "Set `session.id` and `user.id` in your app", "Browse sessions", "User history", "PII considerations".
+- **Edit:** `docs/reference/otel-ingestion.md` — document the resource attributes we read.
+- **Edit:** `docs/reference/serve-api.md` — document new endpoints.
+
+## 4. Storage layout
+
+**No change.** Reads `session.id` and `user.id` from OTel resource attributes already persisted. The DuckDB cache projects resource attributes; this spec adds query patterns over already-indexed columns.
+
+## 5. CLI surface
+
+Lightweight read-only commands:
+
+- `defrost sessions list [--limit <N>] [--user <id>] [--json]`
+- `defrost session show <session-id> [--json]` — print all traces in the session, ordered.
+- `defrost users list [--limit <N>] [--json]`
+- `defrost user show <user-id> [--limit <N>] [--json]` — print recent traces by this user.
+
+## 6. HTTP API surface
+
+In `internal/serve/sessions.go`:
+
+| Method + path | Returns |
+|---|---|
+| `GET /api/sessions?limit=&user=` | `{sessions: [{session_id, user_id?, run_count, first_at, last_at, total_cost_usd?}]}` |
+| `GET /api/sessions/{session-id}` | `{session_id, user_id?, runs: [{run_id, trace_id, ts, status, duration_ms, cost_usd?}]}` |
+| `GET /api/users?limit=` | `{users: [{user_id, run_count, first_at, last_at}]}` |
+| `GET /api/users/{user-id}?limit=` | `{user_id, sessions: [...], runs: [...]}` |
+
+Cache-Control: `public, max-age=60` for all (data updates with new runs).
+
+### Querier extension
+
+In `internal/query/iface.go`:
+
+```go
+type QuerierWithSessions interface {
+    Querier
+    SessionsList(filter SessionFilter) ([]SessionSummary, error)
+    SessionRuns(sessionID string) ([]Run, error)
+    UsersList(filter UserFilter) ([]UserSummary, error)
+    UserRuns(userID string, limit int) ([]Run, error)
+}
+```
+
+Same opt-in pattern as `QuerierWithLookup` and `QuerierWithTraceTree` — DuckDB impl satisfies; future hosted impls plug in or 500 with a clear message.
+
+Implementation in `internal/query/duckdb/sessions.go`: SQL aggregations over the existing span resource-attribute projection.
+
+## 7. Web UI surface
+
+| File | Role |
+|---|---|
+| `web/src/pages/Sessions.tsx` (new) | `/sessions`. Table of sessions (most recent first). Click → session detail. |
+| `web/src/pages/SessionDetail.tsx` (new) | `/sessions/:id`. Timeline of traces in this session, oldest-first. Each row is a small trace summary; click jumps to `/trace/<trace-id>`. |
+| `web/src/pages/Users.tsx` (new) | `/users`. Table of users. |
+| `web/src/pages/UserProfile.tsx` (new) | `/users/:id`. Recent sessions + recent traces. |
+| `web/src/components/HeatmapFilter.tsx` (extended) | Add session / user filter chips to the existing heatmap. |
+
+Empty-state message when no `session.id` resource attribute is found, with a link to `docs/guides/sessions-and-users.md` showing how to set it via OTel SDK.
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/query/duckdb/` | Add `sessions.go` next to existing query files. SQL over the existing `resource_attrs` projection. |
+| `internal/serve/server.go` | Wire endpoints; impl in `internal/serve/sessions.go`. |
+| `internal/cli/cli.go`, `wire.go` | Add `Sessions` / `Users` commands. |
+| `web/src/components/Grid.tsx` | Existing heatmap to add filter chips to. |
+| `web/src/components/RunCell.tsx` | When a session filter is active, dim cells that don't belong to the session. |
+
+**New files only:**
+
+- `internal/query/duckdb/sessions.go` (+ test)
+- `internal/serve/sessions.go` (+ test)
+- `internal/cli/sessions.go` (+ test)
+- `web/src/pages/Sessions.tsx`, `SessionDetail.tsx`, `Users.tsx`, `UserProfile.tsx` plus tests.
+- `docs/guides/sessions-and-users.md`
+
+## 9. OTel emission
+
+This feature is read-only. It does **not** emit telemetry. It surfaces existing OTel resource attributes:
+
+- `session.id` (OTel SemConv reserved; `https://opentelemetry.io/docs/specs/semconv/general/session/`)
+- `user.id` (OTel SemConv reserved)
+
+If a producer also sets `enduser.id` (an older SemConv), treat it as a fallback for `user.id`.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/query/duckdb/sessions_test.go` | Given a fixture with multiple sessions and users, `SessionsList` / `SessionRuns` / `UsersList` / `UserRuns` return the expected aggregations. Filter by `user_id` works. Sort order is stable. |
+| `internal/serve/sessions_test.go` | All endpoints. Pagination via `limit`. |
+| `internal/cli/sessions_test.go` | `defrost sessions list --user alice` returns expected rows. |
+| `web/src/pages/Sessions.test.tsx`, `SessionDetail.test.tsx`, `Users.test.tsx`, `UserProfile.test.tsx` | Render + fetch flows. Empty-state when no session attrs are present. |
+
+## 11. Acceptance criteria
+
+- The dashboard `/sessions` page lists sessions ordered most-recent first, with run counts and time bounds.
+- Clicking a session opens a chronological timeline of its traces.
+- The dashboard `/users` page lists users; clicking opens a profile with recent sessions and traces.
+- The heatmap can be filtered by session or user.
+- An empty-state message guides users on how to set `session.id` / `user.id` via OTel SDK when none are present.
+- `defrost sessions list` / `defrost user show` from the CLI return the same data as the dashboard.
+- Public docs at `docs/guides/sessions-and-users.md` exist and include OTel SDK examples.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+- **PII concerns for `user.id` in self-host.** Many apps emit user emails directly. Recommendation: surface a config flag `DEFROST_HASH_USER_ID=true` (consumed by `internal/otlp/sink.go` at ingestion time) that hashes `user.id` to a stable but opaque value. Document the trade-off. Default off — opt in.
+- **How wide a session?** Some apps treat a "session" as a single conversation; others as a multi-day persistent context. defrost has no opinion. The producer sets `session.id`; we group by it. Document this in the guide.
+- **Cross-repo sessions.** A session that spans multiple deployments (e.g., a microservice fanout) won't be cross-repo-queryable in OSS. Hosted-tier territory. Acknowledge in the guide.
+- **`enduser.id` deprecation.** OTel SemConv has shifted from `enduser.id` to `user.id`. Recommendation: read both, prefer `user.id`. Surface a deprecation hint in the dashboard if a producer is still emitting `enduser.id`.

--- a/docs/_internal/specs/2026-05-05-trace-tree-ui.md
+++ b/docs/_internal/specs/2026-05-05-trace-tree-ui.md
@@ -1,0 +1,241 @@
+# Spec #1 — Trace tree UI
+
+**Date:** 2026-05-05
+**Parent:** [`2026-05-05-eating-the-cake.md`](./2026-05-05-eating-the-cake.md)
+**Status:** Build spec, ready for implementation.
+**Phase:** 1 — close the trace UX gap.
+
+## 1. Goal
+
+Replace the heatmap-only dashboard's blind spot — the inability to inspect a single trace in detail — with a waterfall + nested-tree view of every span in a recorded run, plus a side panel showing one span's full attributes, events, and links. A user lands on `/trace/<trace-id>`, sees the full execution shape of the run, expands/collapses subtrees, and clicks any span to open the detail panel.
+
+## 2. Why this matters competitively
+
+The trace tree is the single highest-leverage UX investment defrost can make. It's the screen LangSmith and Langfuse demos open with — the one users screenshot when they explain why they bought it. Without it, defrost gets dismissed as "the test-history thing" rather than recognised as an LLM observability tool. With it, the rest of Phase 1 (cost/token surfacing, spec [`#2`](./2026-05-05-cost-token-surfacing.md)) hangs off the same screen at near-zero marginal cost.
+
+## 3. Public docs to write first
+
+Per the docs-as-spec rule in `CLAUDE.md`, the public docs page that describes this feature MUST be drafted in the same PR that ships it. Edit:
+
+- **New page:** `docs/guides/inspecting-a-trace.md` — a 1-screen guide. Sections: "Open the dashboard", "Click a run", "Read the waterfall", "Span detail panel", "Search within a trace". Use a screenshot of a real run captured from `defrost exec go test ./...` against this repo (so the screenshot lives at `docs/guides/_assets/trace-tree.png`). Stay neutral — do **not** name LangSmith / Langfuse.
+- **Edit:** `docs/guides/dashboard.md` — add a paragraph linking to the new "Inspecting a trace" guide and update any heatmap-only language that implies the dashboard has only one view.
+- **Edit:** `docs/reference/serve-api.md` — document the two new endpoints from §6.
+- **Edit:** `docs/index.md` — if the home page lists features, add "Inspect any run as a trace tree."
+
+No new concept page is needed. Spans / traces / OTel are already covered in `docs/concepts/otel-as-ingestion.md`.
+
+## 4. Storage layout
+
+**No change.** This spec is read-only against the existing on-disk schema.
+
+The trace tree reads from existing trace files at `<repo>/.defrost/traces/<YYYY>/<MM>/<DD>/<trace-id>.otlp.pb.zst` (canonical OTLP `ExportTraceServiceRequest` protobufs, zstd-compressed). The OTLP message already carries parent/child relationships via `span.parent_span_id`; the tree is reconstructed from that, no schema migration needed.
+
+The DuckDB cache at `<repo>/.defrost/cache.duckdb` is hydrated incrementally by `internal/query/duckdb/`. This spec adds a new column projection (span hierarchy fields) but no new tables — the existing span row already has `span_id`, `parent_span_id`, `name`, `start_time_unix_nano`, `end_time_unix_nano`, `status_code`, and the attribute JSON. Confirm column names against `internal/query/duckdb/` schema before extending.
+
+## 5. CLI surface
+
+**No new CLI commands.** A trace tree is a dashboard concern. If a CLI user wants to dump a trace as JSON, the existing `defrost history` already covers run-level inspection; spawning a span-level CLI is out of scope.
+
+If a future `defrost trace show <trace-id> --json` is wanted, defer to a follow-up spec.
+
+## 6. HTTP API surface
+
+Two new endpoints under `internal/serve/server.go`. Both follow the existing handler conventions in that file (closure over `Deps`, `Cache-Control`, structured DTOs, `writeJSONError` for failure paths).
+
+### `GET /api/trace/{trace-id}/tree`
+
+Returns the nested span hierarchy for one trace.
+
+**Path params:** `trace-id` is the 16-hex-character lower-case ID used by the storage layer (see [`docs/reference/storage-layout.md`](../../reference/storage-layout.md)).
+
+**Query params:** none in v1. (Future: `?expand=root` etc.)
+
+**Response (200):**
+
+```json
+{
+  "trace_id": "0123456789abcdef",
+  "run_id": "<run-id>",
+  "root": {
+    "span_id": "...",
+    "parent_span_id": null,
+    "name": "defrost.run",
+    "kind": "internal",
+    "start_unix_nano": 1746432000000000000,
+    "end_unix_nano":   1746432001234000000,
+    "duration_ms": 1234,
+    "status": "ok",
+    "attributes": { "service.name": "defrost", ... },
+    "events": [ { "name": "...", "time_unix_nano": ..., "attributes": {...} } ],
+    "children": [ { ...same shape... } ]
+  }
+}
+```
+
+The response is one nested tree, root-first. If a trace has multiple roots (orphan spans), wrap them under a synthetic `root: { name: "<trace>", children: [...] }` node and set `synthetic: true`. The dashboard renders the synthetic node collapsed by default.
+
+**Cache-Control:** `public, max-age=86400`. Trace data is immutable after persist (same reasoning as `/api/test/{tid}/run/{rid}`).
+
+**Error paths:**
+- 404 `{"error":"unknown trace"}` if no file matches.
+- 500 with the wrapped error otherwise.
+
+### `GET /api/trace/{trace-id}/raw`
+
+Streams the raw OTLP protobuf for the trace as `application/x-protobuf`. Useful for debugging and for power users who want to pipe into `otel-cli`.
+
+**Cache-Control:** `public, max-age=86400`.
+
+**Body:** the un-zstd'd OTLP `ExportTraceServiceRequest` bytes. (Decompress on the server; we don't push zstd to browsers.)
+
+### Querier extension
+
+Mirror the existing `query.QuerierWithLookup` pattern (defined in `internal/query/iface.go`). Add:
+
+```go
+// QuerierWithTraceTree extends Querier with the per-trace nested
+// hierarchy the /api/trace/<trace-id>/tree endpoint needs. Kept off
+// the base interface so a hosted ClickHouse impl can lazily wire this
+// up — same pattern as QuerierWithLookup.
+type QuerierWithTraceTree interface {
+    Querier
+    LookupTrace(traceID string) (TraceTree, bool, error)
+}
+
+type TraceTree struct {
+    TraceID string
+    RunID   string
+    Root    *Span
+}
+
+type Span struct {
+    SpanID        string
+    ParentSpanID  string
+    Name          string
+    Kind          string
+    StartUnixNano int64
+    EndUnixNano   int64
+    DurationMs    int64
+    Status        string
+    Attributes    map[string]any
+    Events        []SpanEvent
+    Children      []*Span
+}
+
+type SpanEvent struct {
+    Name          string
+    TimeUnixNano  int64
+    Attributes    map[string]any
+}
+```
+
+Implement `LookupTrace` in `internal/query/duckdb/` by SELECTing all spans for a given `trace_id` from the existing span row table, then reconstructing parent/child links in Go.
+
+If the `Querier` does not implement `QuerierWithTraceTree`, the handler returns 500 with `"trace tree not supported by this querier"` (mirrors the existing pattern at `internal/serve/server.go:174–177`).
+
+## 7. Web UI surface
+
+Two new components under `web/src/components/`, one new page under `web/src/pages/`, one route added to `web/src/App.tsx`.
+
+### Components
+
+| Component | File | Role |
+|---|---|---|
+| `TraceTree` | `web/src/components/TraceTree.tsx` | Waterfall + nested-tree rendering. Indented rows with collapsible carets, duration bars sized by span duration, hover highlight. Selects a span on click → updates URL `?span=<span-id>`. |
+| `SpanDetail` | `web/src/components/SpanDetail.tsx` | Right-side panel (shadcn `Sheet`, same primitive as `RunDetailSheet`). Tabs: "Attributes" (key-value table), "Events" (timeline list), "Raw" (JSON dump). Reads `?span=<span-id>` from the URL. |
+| `TraceSearch` | `web/src/components/TraceSearch.tsx` | Inline search box at the top of the tree. Filters span rows whose `name` or any attribute value matches. Highlights matches. Pure client-side (no extra API call). |
+
+### Page
+
+`web/src/pages/TracePage.tsx`:
+
+- Route: `/trace/:traceId` (added to `App.tsx`).
+- Reads `traceId` from the URL.
+- Uses `useQuery({ queryKey: ['trace', traceId], queryFn: () => getTrace(traceId), staleTime: Infinity })` — same staleTime-Infinity pattern as `RunDetailSheet` since trace data is immutable.
+- Renders `<TraceSearch /> <TraceTree /> <SpanDetail />` in a three-column-ish layout (search + tree on the left, detail panel on the right via shadcn `Sheet`).
+- 404 state: matches the existing `RunDetailSheet` 404 message style.
+
+### `web/src/api.ts` additions
+
+```ts
+export async function getTrace(traceId: string): Promise<TraceTreeResponse> { ... }
+```
+
+Plus the `TraceTreeResponse` and `Span` types in `web/src/types.ts`.
+
+### Heatmap link-out
+
+In `web/src/components/RunCell.tsx` (the existing per-cell click target), keep the existing `?run=&test=` behavior, but **add** a "View trace" affordance in `RunDetailSheet` — a button that links to `/trace/<trace-id-derived-from-run-id>`. The `trace_id` for a run is `sha256(run-id)[:16]` per `docs/reference/storage-layout.md`; surface that in the run-detail JSON so the SPA doesn't recompute hashes.
+
+Update `runDetailDTO` in `internal/serve/server.go` to include `TraceID string` field, populated by reading the run's root span's trace_id (already available via the existing entry/run lookup).
+
+## 8. Reuse map
+
+| Existing | Use as |
+|---|---|
+| `internal/serve/server.go` | Add the two new handlers in `New(deps Deps)` following the existing closure-over-deps + `writeJSONError` patterns. |
+| `internal/query/iface.go` | Add `QuerierWithTraceTree` extension and `TraceTree`/`Span`/`SpanEvent` types beside the existing `QuerierWithLookup` / `TestEntry`. |
+| `internal/query/duckdb/` | Implement `LookupTrace`. The schema is already span-shaped from existing OTLP ingest. |
+| `internal/otlp/sink.go` | Existing OTLP-to-on-disk path. **No change.** Verify span-level fields needed for the tree are already persisted (they are, since the heatmap reads them). |
+| `internal/persist/cache.go` | Existing cache hydration. **No change.** The new query method reads from already-hydrated tables. |
+| `web/src/components/RunDetailSheet.tsx` | Pattern to copy for `SpanDetail`. Both are shadcn `Sheet`-based right-side panels. |
+| `web/src/components/Grid.tsx` | Pattern to copy for `TraceTree` data-loading and rendering. |
+| `web/src/api.ts` | Add `getTrace` next to the existing `getTests` / `getTestRun` typed wrappers. |
+| `web/src/queryClient.ts` | Reuse the existing `QueryClient` config. No changes. |
+| `docs/concepts/otel-as-ingestion.md` | Existing concept page; reference from the new guide. |
+| `docs/reference/storage-layout.md` | Source of truth for the `trace_id = sha256(run-id)[:16]` rule. |
+
+**New files only:**
+
+- `internal/query/duckdb/trace_tree.go` (+ `trace_tree_test.go`)
+- `internal/serve/trace.go` (+ `trace_test.go`) — keeps `server.go` from ballooning; mirror how `drop.go`, `metrics.go`, `progress.go` already split out of `server.go`.
+- `web/src/components/TraceTree.tsx` (+ `TraceTree.test.tsx`)
+- `web/src/components/SpanDetail.tsx` (+ `SpanDetail.test.tsx`)
+- `web/src/components/TraceSearch.tsx` (+ `TraceSearch.test.tsx`)
+- `web/src/pages/TracePage.tsx` (+ `TracePage.test.tsx`)
+- `docs/guides/inspecting-a-trace.md` (+ `docs/guides/_assets/trace-tree.png`)
+
+## 9. OTel emission
+
+This feature is read-only. It does **not** emit new telemetry. It surfaces existing OTel data already captured by `internal/otlp/`.
+
+Spans displayed in the tree carry whatever attributes the producer emitted. The tree renders all attributes verbatim — no semantic-convention parsing in this spec. Cost/token surfacing on top of those attributes is spec [`#2`](./2026-05-05-cost-token-surfacing.md), and lands on the same screen at near-zero marginal cost.
+
+## 10. Test plan
+
+| Test file | Asserts |
+|---|---|
+| `internal/query/duckdb/trace_tree_test.go` | Given a fixture trace with N spans (including orphan / multi-root cases), `LookupTrace` returns the expected tree shape. Parent/child wiring is correct. Synthetic root is added iff multi-root. Returns `ok=false` for unknown trace ID. |
+| `internal/serve/trace_test.go` | `httptest.NewServer(New(Deps{...}))` with a stub `Querier` impl satisfying `QuerierWithTraceTree`. Asserts 200 + `Cache-Control: public, max-age=86400` on a known trace; 404 on unknown; 500 with a clean message when the Querier doesn't implement the extension. Asserts `/api/trace/<id>/raw` returns `application/x-protobuf` and the bytes round-trip through `ptraceotlp.UnmarshalProto`. |
+| `web/src/components/TraceTree.test.tsx` | Renders nested rows; collapse/expand toggles children visibility; click row updates the URL via `useSearchParams`; `synthetic: true` root renders collapsed; performance smoke (500-span fixture renders in <500ms in jsdom — use `performance.now()` and assert; this is not a hard guarantee in jsdom but flags pathological regressions). |
+| `web/src/components/SpanDetail.test.tsx` | With `?span=<id>`, reads from query data and renders the three tabs. Empty events list shows empty state. Unknown `?span=` shows inline error, not crash. |
+| `web/src/components/TraceSearch.test.tsx` | Typed query filters rows by name and by any attribute value; clearing query restores all rows. Highlights match in the rendered span name. |
+| `web/src/pages/TracePage.test.tsx` | Route renders against a mocked `getTrace`. 404 path renders a friendly empty state with a link back to the heatmap. |
+| `web/src/api.test.ts` | Existing file; add `getTrace` cases (parses shape; throws on non-2xx). |
+
+Reuse the existing `web/src/test-utils.tsx` `renderWithProviders` helper for all SPA tests. Reuse the existing `httptest`-based server-test pattern from `internal/serve/progress_test.go`.
+
+## 11. Acceptance criteria
+
+The feature is done when **all** are true:
+
+- A user with at least one trace stored can navigate to `/trace/<trace-id>` and see the full span tree with durations.
+- Clicking any span row opens the detail panel; the panel shows all attributes, all events, and the raw JSON tab.
+- The detail panel is deep-linkable: visiting `/trace/<id>?span=<span-id>` opens with that span selected.
+- Search filters span rows by name and attribute value, with matches highlighted.
+- A 500-span trace renders the initial view in <500 ms on a developer's laptop (Chrome, M-series Mac or equivalent). Asserted via the SPA test as a smoke check; manually re-verified during PR review.
+- Multi-root traces render under a synthetic root, collapsed by default, labelled clearly.
+- An unknown `<trace-id>` shows an empty state with a link back to the heatmap, **not** a crash or a 500.
+- The "View trace" button on `RunDetailSheet` links to the correct trace.
+- Public docs `docs/guides/inspecting-a-trace.md` exists with a screenshot, and `docs/reference/serve-api.md` documents the new endpoints. Neither names LangSmith or Langfuse.
+- All test cases in §10 pass.
+
+## 12. Open questions / decisions
+
+These should be flagged at PR time, not silently resolved by the sub-agent.
+
+- **Heatmap vs trace tree as default landing.** Recommendation: heatmap stays the default at `/`. Trace tree is per-run drill-down at `/trace/:id`. Don't replace the heatmap until usage data shows it's dead.
+- **Span row width when durations are extreme.** A trace where one span dominates (>99% of total) makes other bars invisible. Recommendation: switch to log scale via a toggle in the search bar. Spec the toggle but ship linear-scale default.
+- **Performance ceiling.** A trace with >5,000 spans may exceed the 500ms budget. Recommendation: in v1, render the first 1,000 sorted depth-first and show "+ N more spans (show all)". Defer virtualization (`react-virtuoso`) to a follow-up if needed.
+- **Color coding on duration bars.** Use status-derived color (green/red/yellow) or duration-derived color (heatmap)? Recommendation: status-derived, because trace tree's job is debugging not micro-benchmarking. Reuse the existing status palette from `web/src/components/StatusBadge.tsx`.
+- **Trace ID format in the URL.** 16-hex is short and shareable, but OTLP traces in the wild often use 32-hex. Today our writer truncates to 16. Recommendation: continue to use the 16-hex on-disk ID as the URL token; if a user pastes a 32-hex W3C trace ID, the route handler can substring it before lookup. Document this in the new guide.


### PR DESCRIPTION
## Summary

- Adds a parent strategy doc (`2026-05-05-eating-the-cake.md`) ranking LangSmith and Langfuse features by popularity, naming defrost's structural wedges (zero-ops vs Langfuse's ClickHouse+Postgres+Redis+S3 stack; pricing and OSS vs LangSmith), and committing to a "grow with you" hosted-tier path when users outgrow git.
- Adds **ten** deep build specs — one per gap feature — each following an identical 12-section template (goal, competitive framing, public-docs-first plan, storage layout, CLI, HTTP API, web UI, reuse map, OTel emission, test plan, falsifiable acceptance criteria, open questions). Each spec is self-contained so it can be dispatched to a sub-agent for implementation without follow-up clarification.
- All 11 markdown files land in `docs/_internal/specs/` per the `CLAUDE.md` docs-as-spec rule. **No public docs or source code touched** — that work is gated behind individual build PRs that follow this strategy.

## Spec inventory

| # | File | Phase |
|---|---|---|
| 0 | `2026-05-05-eating-the-cake.md` | parent strategy |
| 1 | `2026-05-05-trace-tree-ui.md` | 1 (UX gap) |
| 2 | `2026-05-05-cost-token-surfacing.md` | 1 |
| 3 | `2026-05-05-datasets.md` | 2 |
| 4 | `2026-05-05-llm-as-judge.md` | 3 |
| 5 | `2026-05-05-pairwise-comparison.md` | 3 |
| 6 | `2026-05-05-prompt-management.md` | 4 |
| 7 | `2026-05-05-playground.md` | 4 |
| 8 | `2026-05-05-annotations-feedback.md` | 5 |
| 9 | `2026-05-05-sessions-users.md` | 5 |
| 10 | `2026-05-05-monitoring-dashboards.md` | 5 |

## Notable decisions baked in

- **License is called out as a blocker** in the parent spec (recommend Apache 2.0). We can't credibly position as "the OSS alternative" until `LICENSE` exists at the repo root.
- **Public docs stay neutral** — `docs/guides/`, `docs/reference/`, `docs/concepts/` never name LangSmith / Langfuse. The aggressive positioning lives in the internal spec only.
- **Grow-with-you commitment** is framed as a *promise* (we'll build the next tier with you when git's not enough), not a *cap*. The parent spec points at `internal/query/iface.go` and the existing `query.Querier` seam as evidence the architecture already pre-figures a hosted ClickHouse impl.
- **API keys never persist server-side** in the playground spec — explicit security constraint, with tests required.
- **Annotations use append-only retract pattern** — never erase a line; that's hosted-tier territory if true deletion is ever needed.

## Test plan

- [ ] Reviewer reads `2026-05-05-eating-the-cake.md` end-to-end and the strategy is unambiguous.
- [ ] Pick any one of specs #1–#10; can a sub-agent implement that feature using only the spec + `CLAUDE.md`? Spot-check the trace-tree-ui spec since it's Phase 1 and most likely to be picked up first.
- [ ] Confirm no edits to public `docs/guides/`, `docs/reference/`, `docs/concepts/`, or any source code.
- [ ] Confirm cross-references between specs use the dated filename (so they don't rot when files move).

https://claude.ai/code/session_018yTM8vZpgsLEVt27ijiGJa

---
_Generated by [Claude Code](https://claude.ai/code/session_018yTM8vZpgsLEVt27ijiGJa)_